### PR TITLE
Support NC for all models

### DIFF
--- a/export.py
+++ b/export.py
@@ -581,7 +581,7 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
     assert not (device.type == 'cpu' and half), '--half only compatible with GPU export, i.e. use --device 0'
     model, extras = load_checkpoint(type_='ensemble', weights=weights, device=device)  # load FP32 model
     sparseml_wrapper = extras['sparseml_wrapper']
-    nc, names = extras["ckpt"]["nc"], model.names  # number of classes, class names
+    nc, names = extras["ckpt"].get("nc") or model.nc, model.names  # number of classes, class names
 
     # Checks
     imgsz *= 2 if len(imgsz) == 1 else 1  # expand


### PR DESCRIPTION
The format for storing the nc arg (number of classes) has recently changed in yolov5. This PR updates the loading to accept the old or new format.