### PR TITLE
Fix detect bounding box

### DIFF
--- a/export.py
+++ b/export.py
@@ -492,6 +492,7 @@ def load_checkpoint(
         state_dict = ckpt[model_key].float().state_dict() if pickled else ckpt[model_key]
         if val_type:
             model = DetectMultiBackend(model=model, device=device, dnn=dnn, data=data, fp16=half)
+            model.model.eval()
 
     # turn gradients for params back on in case they were removed
     for p in model.parameters():

--- a/models/common.py
+++ b/models/common.py
@@ -404,9 +404,10 @@ class DetectMultiBackend(nn.Module):
     def forward(self, im, augment=False, visualize=False, val=False):
         # YOLOv5 MultiBackend inference
         b, ch, h, w = im.shape  # batch, channel, height, width
-        if self.pt or self.jit:  # PyTorch
-            y = self.model(im) if self.jit else self.model(im, augment=augment, visualize=visualize)
-            return y if val else y[0]
+        if self.pt:  # PyTorch
+            y = self.model(im, augment=augment, visualize=visualize)[0]
+        elif self.jit:  # TorchScript
+            y = self.model(im)[0]
         elif self.dnn:  # ONNX OpenCV DNN
             im = im.cpu().numpy()  # torch to numpy
             self.net.setInput(im)


### PR DESCRIPTION
Addresses neuralmagic/sparseml#787. Yolov5 v6.0 models are sometimes loaded with training mode turned on, which changes their output set. This PR ensures that they have training turned off when running val and detect scripts.