### PR TITLE
Fix auto build

### DIFF
--- a/.github/workflows/build-wheel-latest.yml
+++ b/.github/workflows/build-wheel-latest.yml
@@ -20,11 +20,11 @@ jobs:
         id: build_wheel
       - name: Upload Wheel Asset
         id: upload-release-asset 
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: svenstaro/upload-release-action@v2
         with:
-          upload_url: "https://uploads.github.com/repos/neuralmagic/yolov5/releases/65514986/assets{?name,label}" 
-          asset_path: ${{ steps.build_wheel.outputs.wheel_path }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ steps.build_wheel.outputs.wheel_path }}
           asset_name: ${{ steps.build_wheel.outputs.wheel_name }}
-          asset_content_type: application/whl
+          tag: "nightly"
+          overwrite: true
+          body: "This is my release text"

--- a/.github/workflows/build-wheel-latest.yml
+++ b/.github/workflows/build-wheel-latest.yml
@@ -1,6 +1,6 @@
 ---
 name: Upload Nightly Wheel
- 
+
 on:
   push:
     branches:

--- a/.github/workflows/build-wheel-latest.yml
+++ b/.github/workflows/build-wheel-latest.yml
@@ -4,7 +4,7 @@ name: Upload Nightly Wheel
 on:
   push:
     branches:
-      - "master"
+      - "fix-auto-build"
 
 jobs:
   build-wheel:

--- a/.github/workflows/build-wheel-latest.yml
+++ b/.github/workflows/build-wheel-latest.yml
@@ -27,4 +27,3 @@ jobs:
           asset_name: ${{ steps.build_wheel.outputs.wheel_name }}
           tag: "nightly"
           overwrite: true
-          body: "This is my release text"

--- a/.github/workflows/build-wheel-latest.yml
+++ b/.github/workflows/build-wheel-latest.yml
@@ -4,7 +4,7 @@ name: Upload Nightly Wheel
 on:
   push:
     branches:
-      - "fix-auto-build"
+      - "master"
 
 jobs:
   build-wheel:

--- a/.github/workflows/build-wheel-latest.yml
+++ b/.github/workflows/build-wheel-latest.yml
@@ -1,6 +1,6 @@
 ---
 name: Upload Nightly Wheel
-
+ 
 on:
   push:
     branches:


### PR DESCRIPTION
Currently, auto build uses the default `actions/upload-release-asset@v1`. This action does not support overwriting assets and is archived and no longer supported by the development team. 

This PR updates to `svenstaro/upload-release-action@v2` which includes overwrite support and is still maintained to some degree. 

Two upload tests were ran by changing the tracked branch from `master` to `fix-auto-build`. Tests confirmed that the wheel asset was updated after each one
https://github.com/neuralmagic/yolov5/actions/runs/2384881912
https://github.com/neuralmagic/yolov5/actions/runs/2384891594