### PR TITLE
[Fix] Explicit loggers include

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,5 @@ include setup.py
 recursive-include yolov5/data *
 recursive-include yolov5/models *
 recursive-include yolov5/models_v5.0 *
+recursive-include yolov5/utils/loggers *.py
 include yolov5/requirements.txt


### PR DESCRIPTION
There is an ephemeral error where building the wheel will exclude the utils/loggers directory. 

This PR explicitly adds the directory to the manifest file
