### PR TITLE
change onnx `input_names` variable to `[images]`

### DIFF
--- a/export.py
+++ b/export.py
@@ -143,7 +143,7 @@ def export_onnx(model, im, file, opset, train, dynamic, simplify, prefix=colorst
 
         outputs = model(im)
         num_outputs = _count_outputs(outputs)
-        input_names = ['input']
+        input_names = ['images']
         output_names = [f'out_{i}' for i in range(num_outputs)]
         dynamic_axes = {k: {0: 'batch'} for k in (input_names + output_names)} if dynamic else None
         exporter = ModuleExporter(model, save_dir)


### PR DESCRIPTION
The current `export.py` script results in an error if we specify the `--simplify` argument.

Here is the error message on my machine.

```bash
ONNX: simplifying with onnx-simplifier 0.3.10...
ONNX: simplifier failure: The model doesn't have input named "images"
ONNX: export success, saved as yolov5-deepsparse/yolov5s-sgd/weights/best.onnx (26.9 MB)
```
This PR changes the input name from `input` to `images` to fix that.