### PR TITLE
Feature/move sample creation to export script

### DIFF
--- a/export.py
+++ b/export.py
@@ -72,6 +72,7 @@ from utils.general import (LOGGER, ROOT, check_dataset, check_img_size, check_re
 from utils.torch_utils import select_device, torch_distributed_zero_first, is_parallel
 from utils.downloads import attempt_download
 from utils.sparse import SparseMLWrapper, check_download_sparsezoo_weights
+from utils.datasets import create_dataloader
 
 FILE = Path(__file__).resolve()
 LOCAL_ROOT = FILE.parents[0]  # YOLOv5 root directory
@@ -465,7 +466,10 @@ def load_checkpoint(
     max_train_steps=-1,
     ):
     with torch_distributed_zero_first(rank):
+
         # download if not found locally or from sparsezoo if stub
+        print(check_download_sparsezoo_weights(weights))
+        print(weights)
         weights = attempt_download(weights) or check_download_sparsezoo_weights(weights)
     ckpt = torch.load(weights[0] if isinstance(weights, list) or isinstance(weights, tuple)
                       else weights, map_location="cpu")  # load checkpoint
@@ -580,6 +584,7 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
         iou_thres=0.45,  # TF.js NMS: IoU threshold
         conf_thres=0.25,  # TF.js NMS: confidence threshold
         remove_grid=False,
+        num_export_samples = 0 # number of data samples to generate
         ):
     t = time.time()
     include = [x.lower() for x in include]  # to lowercase
@@ -640,6 +645,19 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
     if coreml:
         _, f[4] = export_coreml(model, im, file)
 
+    # Sample data Exports
+    if num_export_samples > 0:
+        val_loader = create_dataloader(val_path, imgsz, batch_size, gs, single_cls,
+                                       hyp=hyp, cache=None if noval else opt.cache,
+                                       rect=True, rank=-1, workers=workers * 2, pad=0.5,
+                                       prefix=colorstr('val: '))[0]
+        sparseml_wrapper.save_sample_inputs_outputs(
+            dataloader=val_loader,
+            num_export_samples=num_export_samples,
+            save_dir=str(w),
+            image_size=imgsz,
+        )
+
     # TensorFlow Exports
     if any((saved_model, pb, tflite, edgetpu, tfjs)):
         if int8 or edgetpu:  # TFLite --int8 bug https://github.com/ultralytics/yolov5/issues/5707
@@ -673,6 +691,7 @@ def parse_opt(known = False, skip_parse = False):
     parser = argparse.ArgumentParser()
     parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='dataset.yaml path')
     parser.add_argument('--weights', nargs='+', type=str, default=ROOT / 'yolov5s.pt', help='model.pt path(s)')
+    parser.add_argument('--num-export-samples', type=int, default=0, help='number of sample inputs/outputs to export')
     parser.add_argument('--imgsz', '--img', '--img-size', nargs='+', type=int, default=[640, 640], help='image (h, w)')
     parser.add_argument('--batch-size', type=int, default=1, help='batch size')
     parser.add_argument('--device', default='cpu', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')

--- a/export.py
+++ b/export.py
@@ -647,14 +647,18 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
 
     # Sample data Exports
     if num_export_samples > 0:
-        val_loader = create_dataloader(val_path, imgsz, batch_size, gs, single_cls,
-                                       hyp=hyp, cache=None if noval else opt.cache,
-                                       rect=True, rank=-1, workers=workers * 2, pad=0.5,
-                                       prefix=colorstr('val: '))[0]
+        LOGGER.info(f"\n{colorstr('Exporting data samples:')} {num_export_samples} in total.")
+        # Image size
+        gs = max(int(model.stride.max()), 32)  # grid size (max stride)
+        imgsz = check_img_size(opt.imgsz, gs, floor=gs * 2) # verify imgsz is gs-multiple
+        if isinstance(imgsz, list):
+            imgsz = imgsz[0]
+
+        val_loader = create_dataloader(path=check_dataset(data)['val'], imgsz=imgsz, batch_size=batch_size, stride=gs)[0]
         sparseml_wrapper.save_sample_inputs_outputs(
             dataloader=val_loader,
             num_export_samples=num_export_samples,
-            save_dir=str(w),
+            save_dir= os.path.dirname(file),
             image_size=imgsz,
         )
 

--- a/export.py
+++ b/export.py
@@ -468,8 +468,6 @@ def load_checkpoint(
     with torch_distributed_zero_first(rank):
 
         # download if not found locally or from sparsezoo if stub
-        print(check_download_sparsezoo_weights(weights))
-        print(weights)
         weights = attempt_download(weights) or check_download_sparsezoo_weights(weights)
     ckpt = torch.load(weights[0] if isinstance(weights, list) or isinstance(weights, tuple)
                       else weights, map_location="cpu")  # load checkpoint

--- a/train.py
+++ b/train.py
@@ -543,13 +543,6 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
         callbacks.run('on_train_end', last, best, plots, epoch, results)
         LOGGER.info(f"Results saved to {colorstr('bold', save_dir)}")
 
-    if opt.num_export_samples > 0:
-        sparseml_wrapper.save_sample_inputs_outputs(
-            dataloader=val_loader or train_loader,
-            num_export_samples=opt.num_export_samples,
-            save_dir=str(w),
-            image_size=imgsz,
-        )
 
     torch.cuda.empty_cache()
     return results
@@ -608,7 +601,6 @@ def parse_opt(known=False, skip_parse=False):
     parser.add_argument("--max-eval-steps", type=int, default=-1, help="Set the maximum number of eval steps per epoch. if negative,"
                                                                         "the entire dataset will be used, default=-1")
     parser.add_argument("--one-shot", action="store_true", default=False, help="Apply recipe in one shot manner")
-    parser.add_argument("--num-export-samples", type=int, default=0, help="The number of sample inputs/outputs to export, default=0")
 
     if skip_parse:
         opt = parser.parse_args([])

--- a/train.py
+++ b/train.py
@@ -321,15 +321,6 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
         torch.save(ckpt, one_shot_checkpoint_name)
         LOGGER.info(f"One shot checkpoint saved to {one_shot_checkpoint_name}")
 
-        if opt.num_export_samples > 0:
-            dataloader = val_loader or train_loader
-            sparseml_wrapper.save_sample_inputs_outputs(
-                dataloader=dataloader,
-                num_export_samples=opt.num_export_samples,
-                save_dir=str(w),
-                image_size=imgsz,
-            )
-
         del ckpt
 
         torch.cuda.empty_cache()

--- a/utils/sparse.py
+++ b/utils/sparse.py
@@ -27,6 +27,7 @@ def _get_model_framework_file(model, path):
     if transfer_request and checkpoint_available:
         # checkpoints are saved for transfer learning use cases,
         # return checkpoint if avaiable and requested
+        print([file for file in available_files if ".ckpt" in file.name][0])
         return [file for file in available_files if ".ckpt" in file.name][0]
     elif final_available:
         # default to returning final state, if available


### PR DESCRIPTION
## Description
Moving the sample creation functionality from `train.py` to `export.py`.

## Testing
### Manual Testing

Running the code below without errors:

```bash
yolov5/export.py --num-export-samples 10

...
Exporting data samples: 10 in total.
Scanning 'datasets/coco128/labels/train2017.cache' images and labels... 128 found
Exported 10 samples to ../sparseml/src/sparseml/yolov5
...
```

```python
import os
from sparsezoo import load_numpy_list
import onnx
import onnxruntime as ort
import numpy as np

path = "/home/damian/sparseml/src/sparseml/yolov5"

sample_input = load_numpy_list(os.path.join(path, "sample-inputs/inp-0000.npz"))
sample_output = load_numpy_list(os.path.join(path, "sample-outputs/out-0000.npz"))

onnx_model = onnx.load(os.path.join(path, "yolov5s.onnx"))
onnx.checker.check_model(os.path.join(path, "yolov5s.onnx"))

ort_sess = ort.InferenceSession(os.path.join(path, "yolov5s.onnx"))

outputs = ort_sess.run(None, {'input': sample_input[0]['arr_0'][None, ...]})

for o1, o2 in zip(outputs, sample_output[0].values()):
    tolerance = 1e-02 
    """
    Tolerance is relatively low. this is because I am evaluating 
    files generated by the .pth model using onnxruntime.
    """
    assert np.all(np.isclose(o1[0],o2, atol=tolerance))
```