### PR TITLE
Make choosing weights from stub + recipe string arg more robust to the input

### DIFF
--- a/utils/sparse.py
+++ b/utils/sparse.py
@@ -3,11 +3,10 @@ import math
 import random
 import os
 from typing import Any, Dict, Optional
-
+from re import search
 from sparsezoo import Model
 from sparseml.pytorch.optim import ScheduledModifierManager
 from sparseml.pytorch.utils import SparsificationGroupLogger
-from sparseml.pytorch.utils import GradSampler
 from sparseml.pytorch.sparsification.quantization import QuantizationModifier
 import torchvision.transforms.functional as F
 
@@ -20,13 +19,13 @@ _LOGGER = logging.getLogger(__file__)
 
 def _get_model_framework_file(model, path):
     available_files = model.training.default.files
-    transfer_request = 'recipe_type=transfer' in path
+    transfer_request = search("recipe(.*)transfer", path)
     checkpoint_available = any([".ckpt" in file.name for file in available_files])
     final_available = any([not ".ckpt" in file.name for file in available_files])
 
     if transfer_request and checkpoint_available:
         # checkpoints are saved for transfer learning use cases,
-        # return checkpoint if avaiable and requested
+        # return checkpoint if available and requested
         return [file for file in available_files if ".ckpt" in file.name][0]
     elif final_available:
         # default to returning final state, if available


### PR DESCRIPTION
The user may wish to specify the string arguments for communication with zoo server.

Before, the user needs to stick to one pathway:
`{stub}?recipe_type={...}`

Now it also accepts the default argument 
`{stub}?recipe={...}`