### PR TITLE
Add grad accumulation control

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ Pillow>=7.1.2
 PyYAML>=5.3.1
 requests>=2.23.0
 scipy>=1.4.1
+torchvision>=0.8.1
 tqdm>=4.41.0
 
 # Logging -------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ Pillow>=7.1.2
 PyYAML>=5.3.1
 requests>=2.23.0
 scipy>=1.4.1
-torchvision>=0.8.1
 tqdm>=4.41.0
 
 # Logging -------------------------------------

--- a/train.py
+++ b/train.py
@@ -166,7 +166,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
         loggers.on_params_update({"batch_size": batch_size})
 
     # Optimizer
-    nbs = 64  # nominal batch size
+    nbs = batch_size*opt.gradient_accum_steps if opt.overwrite_batch_size else 64   # nominal batch size
     accumulate = max(round(nbs / batch_size), 1)  # accumulate loss before optimizing
     hyp['weight_decay'] *= batch_size * accumulate / nbs  # scale weight_decay
     LOGGER.info(f"Scaled weight_decay = {hyp['weight_decay']}")
@@ -563,6 +563,9 @@ def parse_opt(known=False, skip_parse=False):
     parser.add_argument('--hyp', type=str, default=ROOT / 'data/hyps/hyp.scratch-low.yaml', help='hyperparameters path')
     parser.add_argument('--epochs', type=int, default=300)
     parser.add_argument('--batch-size', type=int, default=16, help='total batch size for all GPUs, -1 for autobatch')
+    parser.add_argument('--gradient_accum_steps', type=int, default=1, help="Number of gradient accumulation steps")
+    parser.add_argument('--overwrite_batch_size', type=bool, default=False, help="If true, overwrite default nominal batch size "
+                                                                    "of 64 with product of batch size and gradient accumulation steps")
     parser.add_argument('--imgsz', '--img', '--img-size', type=int, default=640, help='train, val image size (pixels)')
     parser.add_argument('--rect', action='store_true', help='rectangular training')
     parser.add_argument('--resume', 

--- a/train.py
+++ b/train.py
@@ -166,8 +166,8 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
         loggers.on_params_update({"batch_size": batch_size})
 
     # Optimizer
-    nbs = batch_size*opt.gradient_accum_steps if opt.gradient_accum_steps else 64   # nominal batch size
-    accumulate = max(round(nbs / batch_size), 1)  # accumulate loss before optimizing
+    nbs = batch_size*opt.gradient_accum_steps   # nominal batch size
+    accumulate = opt.gradient_accum_steps  # accumulate loss before optimizing
     hyp['weight_decay'] *= batch_size * accumulate / nbs  # scale weight_decay
     LOGGER.info(f"Scaled weight_decay = {hyp['weight_decay']}")
 
@@ -563,9 +563,7 @@ def parse_opt(known=False, skip_parse=False):
     parser.add_argument('--hyp', type=str, default=ROOT / 'data/hyps/hyp.scratch-low.yaml', help='hyperparameters path')
     parser.add_argument('--epochs', type=int, default=300)
     parser.add_argument('--batch-size', type=int, default=16, help='total batch size for all GPUs, -1 for autobatch')
-    parser.add_argument('--gradient-accum-steps', type=int, default=None, help="Number of gradient accumulation steps. If set, "
-                                                                            "overwrite default nominal batch size of 64 with"
-                                                                            "product of batch size and gradient accumulation steps")
+    parser.add_argument('--gradient-accum-steps', type=int, default=1, help="Number of gradient accumulation steps")
     parser.add_argument('--imgsz', '--img', '--img-size', type=int, default=640, help='train, val image size (pixels)')
     parser.add_argument('--rect', action='store_true', help='rectangular training')
     parser.add_argument('--resume', 

--- a/train.py
+++ b/train.py
@@ -166,7 +166,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
         loggers.on_params_update({"batch_size": batch_size})
 
     # Optimizer
-    nbs = batch_size*opt.gradient_accum_steps if opt.overwrite_batch_size else 64   # nominal batch size
+    nbs = batch_size*opt.gradient_accum_steps if opt.gradient_accum_steps else 64   # nominal batch size
     accumulate = max(round(nbs / batch_size), 1)  # accumulate loss before optimizing
     hyp['weight_decay'] *= batch_size * accumulate / nbs  # scale weight_decay
     LOGGER.info(f"Scaled weight_decay = {hyp['weight_decay']}")
@@ -563,9 +563,9 @@ def parse_opt(known=False, skip_parse=False):
     parser.add_argument('--hyp', type=str, default=ROOT / 'data/hyps/hyp.scratch-low.yaml', help='hyperparameters path')
     parser.add_argument('--epochs', type=int, default=300)
     parser.add_argument('--batch-size', type=int, default=16, help='total batch size for all GPUs, -1 for autobatch')
-    parser.add_argument('--gradient_accum_steps', type=int, default=1, help="Number of gradient accumulation steps")
-    parser.add_argument('--overwrite_batch_size', type=bool, default=False, help="If true, overwrite default nominal batch size "
-                                                                    "of 64 with product of batch size and gradient accumulation steps")
+    parser.add_argument('--gradient-accum-steps', type=int, default=None, help="Number of gradient accumulation steps. If set, "
+                                                                            "overwrite default nominal batch size of 64 with"
+                                                                            "product of batch size and gradient accumulation steps")
     parser.add_argument('--imgsz', '--img', '--img-size', type=int, default=640, help='train, val image size (pixels)')
     parser.add_argument('--rect', action='store_true', help='rectangular training')
     parser.add_argument('--resume', 


### PR DESCRIPTION
Add control over gradient accumulation steps and nominal batch size via the arg `--gradient_accum_steps`. If the arg is not set, the default nominal batch size of 64 is honored. If it is set, the nominal batch size is set to be the product of the the batch size and the gradient accumulation steps.

Tests:
`sparseml.yolov5.train --epoch 1`
`sparseml.yolov5.train --epoch 1 --gradient-accum-steps 4 --batch-size 16`

