### PR TITLE
Add torchvision as dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ Pillow>=7.1.2
 PyYAML>=5.3.1
 requests>=2.23.0
 scipy>=1.4.1
+torch>=1.7.0
+torchvision>=0.8.1
 tqdm>=4.41.0
 
 # Logging -------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ Pillow>=7.1.2
 PyYAML>=5.3.1
 requests>=2.23.0
 scipy>=1.4.1
-torch>=1.7.0
 torchvision>=0.8.1
 tqdm>=4.41.0
 


### PR DESCRIPTION
Add torchvision dependancy so that even if a user doesn't install sparseml with torchvision, they can successfully install yolov5. This potential issue was discovered by @rahul-tuli 