### PR TITLE
Set name of the export onnx model to 'model.onnx'

### DIFF
--- a/export.py
+++ b/export.py
@@ -78,6 +78,7 @@ LOCAL_ROOT = FILE.parents[0]  # YOLOv5 root directory
 if str(LOCAL_ROOT) not in sys.path:
     sys.path.append(str(LOCAL_ROOT))  # add ROOT to PATH
 LOCAL_ROOT = Path(os.path.relpath(LOCAL_ROOT, Path.cwd()))  # relative
+MODEL_ONNX_NAME = "model.onnx"
 
 def export_formats():
     # YOLOv5 export formats
@@ -122,7 +123,7 @@ def export_onnx(model, im, file, opset, train, dynamic, simplify, prefix=colorst
         import onnx
 
         LOGGER.info(f'\n{prefix} starting export with onnx {onnx.__version__}...')
-        f = file.with_suffix('.onnx')
+        f = Path(os.path.join(file.parent), MODEL_ONNX_NAME)
 
         # export through SparseML so quantized and pruned graphs can be corrected
         save_dir = f.parent.absolute()


### PR DESCRIPTION
# Testing:
```bash
YOLOv5 🚀 2022-8-3 torch 1.9.1+cu111 CPU

Fusing layers... 
YOLOv5s summary: 213 layers, 7225885 parameters, 0 gradients, 16.4 GFLOPs

PyTorch: starting from ../sparseml/src/sparseml/yolov5/yolov5s.pt with output shape (1, 25200, 85) (14.1 MB)

TorchScript: starting export with torch 1.9.1+cu111...
TorchScript: export success, saved as ../sparseml/src/sparseml/yolov5/yolov5s.torchscript (28.0 MB)

ONNX: starting export with onnx 1.10.1...
ONNX: export success, saved as ../sparseml/src/sparseml/yolov5/model.onnx (28.0 MB)

Export complete (2.64s)
Results saved to /home/damian/sparseml/src/sparseml/yolov5
Detect:          python detect.py --weights ../sparseml/src/sparseml/yolov5/model.onnx
PyTorch Hub:     model = torch.hub.load('ultralytics/yolov5', 'custom', '../sparseml/src/sparseml/yolov5/model.onnx')
Validate:        python val.py --weights ../sparseml/src/sparseml/yolov5/model.onnx
Visualize:       https://netron.app

Process finished with exit code 0
```