### PR TITLE
Fix zoo export

### DIFF
--- a/export.py
+++ b/export.py
@@ -519,6 +519,12 @@ def load_checkpoint(
                       anchors=hyp.get('anchors') if hyp else None).to(device)
         model_key = 'ema' if (not train_type and 'ema' in ckpt and ckpt['ema']) else 'model'
         state_dict = ckpt[model_key].float().state_dict() if pickled else ckpt[model_key]
+
+        # backwards compatability for sparsezoo models that maintain anchor grid in state dict
+        anchor_grid_key = [key for key in state_dict.keys() if "anchor_grid" in key]
+        if len(anchor_grid_key) == 1:
+            _ = [state_dict.pop(key) for key in anchor_grid_key]
+
         if val_type:
             model = DetectMultiBackend(model=model, device=device, dnn=dnn, data=data, fp16=half)
 

--- a/train.py
+++ b/train.py
@@ -166,7 +166,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
         loggers.on_params_update({"batch_size": batch_size})
 
     # Optimizer
-    nbs = batch_size*opt.gradient_accum_steps if opt.overwrite_batch_size else 64   # nominal batch size
+    nbs = 64  # nominal batch size
     accumulate = max(round(nbs / batch_size), 1)  # accumulate loss before optimizing
     hyp['weight_decay'] *= batch_size * accumulate / nbs  # scale weight_decay
     LOGGER.info(f"Scaled weight_decay = {hyp['weight_decay']}")
@@ -547,9 +547,6 @@ def parse_opt(known=False, skip_parse=False):
     parser.add_argument('--hyp', type=str, default=ROOT / 'data/hyps/hyp.scratch-low.yaml', help='hyperparameters path')
     parser.add_argument('--epochs', type=int, default=300)
     parser.add_argument('--batch-size', type=int, default=16, help='total batch size for all GPUs, -1 for autobatch')
-    parser.add_argument('--gradient_accum_steps', type=int, default=1, help="Number of gradient accumulation steps")
-    parser.add_argument('--overwrite_batch_size', type=bool, default=False, help="If true, overwrite default nominal batch size "
-                                                                    "of 64 with product of batch size and gradient accumulation steps")
     parser.add_argument('--imgsz', '--img', '--img-size', type=int, default=640, help='train, val image size (pixels)')
     parser.add_argument('--rect', action='store_true', help='rectangular training')
     parser.add_argument('--resume', 

--- a/train.py
+++ b/train.py
@@ -166,7 +166,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
         loggers.on_params_update({"batch_size": batch_size})
 
     # Optimizer
-    nbs = 64  # nominal batch size
+    nbs = batch_size*opt.gradient_accum_steps if opt.overwrite_batch_size else 64   # nominal batch size
     accumulate = max(round(nbs / batch_size), 1)  # accumulate loss before optimizing
     hyp['weight_decay'] *= batch_size * accumulate / nbs  # scale weight_decay
     LOGGER.info(f"Scaled weight_decay = {hyp['weight_decay']}")
@@ -547,6 +547,9 @@ def parse_opt(known=False, skip_parse=False):
     parser.add_argument('--hyp', type=str, default=ROOT / 'data/hyps/hyp.scratch-low.yaml', help='hyperparameters path')
     parser.add_argument('--epochs', type=int, default=300)
     parser.add_argument('--batch-size', type=int, default=16, help='total batch size for all GPUs, -1 for autobatch')
+    parser.add_argument('--gradient_accum_steps', type=int, default=1, help="Number of gradient accumulation steps")
+    parser.add_argument('--overwrite_batch_size', type=bool, default=False, help="If true, overwrite default nominal batch size "
+                                                                    "of 64 with product of batch size and gradient accumulation steps")
     parser.add_argument('--imgsz', '--img', '--img-size', type=int, default=640, help='train, val image size (pixels)')
     parser.add_argument('--rect', action='store_true', help='rectangular training')
     parser.add_argument('--resume', 


### PR DESCRIPTION
This PR removes `anchor_grid` from the state dict/ unpickled model if it is found. Legacy sparsezoo models (v5.0) are saved with `anchor_grid`. This causes issues as `anchor_grid` processing has been updated between versions and the legacy `anchor_grid` are not in the correct format to be processed successfully. The values for `anchor_grid` are determined from the `Detect` layer's `anchors` on runtime and are not needed for model loading/saving.

**Manual Testing**
`sparseml.yolov5.export_onnx --weights zoo:cv/detection/yolov5-l/pytorch/ultralytics/coco/pruned-aggressive_98`
 
`sparseml.yolov5.export_onnx --weights zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned_quant-aggressive_94`

```
sparseml.yolov5.train --cfg models/yolov5s.yaml --epochs 1
sparseml.yolov5.export_onnx --weights yolov5_runs/train/exp/weights/last.pt
```

```
sparseml.yolov5.train --cfg models_v5.0/yolov5s.yaml --epochs 1
sparseml.yolov5.export_onnx --weights yolov5_runs/train/exp/weights/last.pt
```

```
sparseml.yolov5.train --one-shot --cfg models_v5.0/yolov5l.yaml --recipe zoo:cv/detection/yolov5-l/pytorch/ultralytics/coco/pruned-aggressive_98
sparseml.yolov5.export_onnx --weights yolov5_runs/train/exp/weights/checkpoint-one-shot.pt
```

```
sparseml.yolov5.train --one-shot --cfg models_v5.0/yolov5l.yaml --recipe zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned_quant-aggressive_94
sparseml.yolov5.export_onnx --weights yolov5_runs/train/exp/weights/checkpoint-one-shot.pt
```



**Almost Automatic Testing**
`make testinteg TARGETS=yolov5`

`SPARSEML_TEST_CADENCE='commit' make testinteg TARGETS=yolov5`