### PR TITLE
Update build_wheel.sh copy list

### DIFF
--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -1,6 +1,6 @@
 python3 -m pip install --upgrade build
 mkdir yolov5
-cp -r data models models_v5.0 utils .pre-commit-config.yaml $(ls *.py) requirements.txt yolov5/
+cp -r models utils .pre-commit-config.yaml $(ls *.py) requirements.txt yolov5/
 grep --include=\*.py -rnl 'yolov5/' -e "from models" | xargs -i@ sed -i 's/from models/from yolov5.models/g' @
 grep --include=\*.py -rnl 'yolov5/' -e "from utils" | xargs -i@ sed -i 's/from utils/from yolov5.utils/g' @
 sed -i '/^sparseml/d' yolov5/requirements.txt


### PR DESCRIPTION
`data` and `models_v5.0` dirs are now housed on the sparseml side, so running `build_wheel.sh` will throw innocuous warnings about the missing dirs. This PR removes them from the copy list. 