### PR TITLE
Add option to not convert qat graph on export

### DIFF
--- a/export.py
+++ b/export.py
@@ -748,8 +748,8 @@ def parse_opt(known = False, skip_parse = False):
     parser.add_argument("--no_convert_qat",
                         action="store_true",
                         help = (
-                            "if True, exports of torch QAT graphs will be converted "
-                            "to a fully quantized representation. Default is True "
+                            "if specified, exports of torch QAT graphs will skip conversion "
+                            "to a fully quantized representation. Default is False "
                             )
                         )
     if skip_parse:

--- a/export.py
+++ b/export.py
@@ -117,7 +117,7 @@ def export_torchscript(model, im, file, optimize, prefix=colorstr('TorchScript:'
         LOGGER.info(f'{prefix} export failure: {e}')
 
 
-def export_onnx(model, im, file, opset, train, dynamic, simplify, prefix=colorstr('ONNX:')):
+def export_onnx(model, im, file, opset, train, dynamic, simplify, prefix=colorstr('ONNX:'), convert_qat=True):
     # YOLOv5 ONNX export
     try:
         check_requirements(('onnx',))
@@ -147,7 +147,7 @@ def export_onnx(model, im, file, opset, train, dynamic, simplify, prefix=colorst
         output_names = [f'out_{i}' for i in range(num_outputs)]
         dynamic_axes = {k: {0: 'batch'} for k in (input_names + output_names)} if dynamic else None
         exporter = ModuleExporter(model, save_dir)
-        exporter.export_onnx(im, name=save_name, convert_qat=True,
+        exporter.export_onnx(im, name=save_name, convert_qat=convert_qat,
                                 input_names=input_names, output_names=output_names, dynamic_axes=dynamic_axes)
         try:
             skip_onnx_input_quantize(str(f), str(f))
@@ -605,7 +605,8 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
         iou_thres=0.45,  # TF.js NMS: IoU threshold
         conf_thres=0.25,  # TF.js NMS: confidence threshold
         remove_grid=False,
-        num_export_samples = 0 # number of data samples to generate
+        num_export_samples = 0, # number of data samples to generate
+        no_convert_qat=False,
         ):
     t = time.time()
     include = [x.lower() for x in include]  # to lowercase
@@ -660,7 +661,7 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
     if engine:  # TensorRT required before ONNX
         f[1] = export_engine(model, im, file, train, half, simplify, workspace, verbose)
     if onnx or xml:  # OpenVINO requires ONNX
-        f[2] = export_onnx(model, im, file, opset, train, dynamic, simplify)
+        f[2] = export_onnx(model, im, file, opset, train, dynamic, simplify, convert_qat = (not no_convert_qat))
     if xml:  # OpenVINO
         f[3] = export_openvino(model, im, file)
     if coreml:
@@ -744,6 +745,13 @@ def parse_opt(known = False, skip_parse = False):
     parser.add_argument('--include', nargs='+',
                         default=['torchscript', 'onnx'],
                         help='torchscript, onnx, openvino, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs')
+    parser.add_argument("--no_convert_qat",
+                        action="store_true",
+                        help = (
+                            "if True, exports of torch QAT graphs will be converted "
+                            "to a fully quantized representation. Default is True "
+                            )
+                        )
     if skip_parse:
         opt = parser.parse_args([])
     elif known:


### PR DESCRIPTION
This PR adds the option to export a QAT yolov5 model without converting the graph to a pure quantized one via the `--no_convert_qat` arg.


**Manual Testing**
```
sparseml.yolov5.train --one-shot --cfg models_v5.0/yolov5l.yaml --recipe zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned_quant-aggressive_94
sparseml.yolov5.export_onnx --weights yolov5_runs/train/exp/weights/checkpoint-one-shot.pt --no_convert_qat
```

Snippet of graph created with `--no_convert_qat`

<img width="724" alt="Screen Shot 2022-08-30 at 5 39 16 PM" src="https://user-images.githubusercontent.com/66528950/187492480-5bda67c5-b743-4b07-a49c-3f5b801c806e.png">

**Almost Automatic Testing**
`make testinteg TARGETS=yolov5`

`SPARSEML_TEST_CADENCE='commit' make testinteg TARGETS=yolov5`


