### PR TITLE
Fix DDP + max_steps

### DIFF
--- a/train.py
+++ b/train.py
@@ -436,8 +436,9 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
 
             if 0 < opt.max_train_steps <= train_steps_executed:
 
-                pbar.update(1)
-                pbar.close()
+                if RANK in [-1, 0]:
+                    pbar.update(1)
+                    pbar.close()
                 break
             # end batch ------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Currently, when running ddp with max_steps set, the run will fail on non-main nodes as they will attempt to update an undefined progress bar. This PR patches that issue.