### PR TITLE
Add data-path arg

### DIFF
--- a/export.py
+++ b/export.py
@@ -589,6 +589,7 @@ def load_state_dict(model, state_dict, run_mode, exclude_anchors):
 
 @torch.no_grad()
 def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
+        data_path='', # optional data path to overwrite one written in .yaml data file
         weights=ROOT / 'yolov5s.pt',  # weights path
         imgsz=(640, 640),  # image (height, width)
         batch_size=1,  # batch size
@@ -681,7 +682,7 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
         if isinstance(imgsz, list):
             imgsz = imgsz[0]
 
-        val_loader = create_dataloader(path=check_dataset(data)['val'], imgsz=imgsz, batch_size=batch_size, stride=gs)[0]
+        val_loader = create_dataloader(path=check_dataset(data, data_path)['val'], imgsz=imgsz, batch_size=batch_size, stride=gs)[0]
         sparseml_wrapper.save_sample_inputs_outputs(
             dataloader=val_loader,
             num_export_samples=num_export_samples,
@@ -725,6 +726,7 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
 def parse_opt(known = False, skip_parse = False):
     parser = argparse.ArgumentParser()
     parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='dataset.yaml path')
+    parser.add_argument('--data-path', type=str, default= '', help='path to dataset to overwrite the path in dataset.yaml')
     parser.add_argument('--weights', nargs='+', type=str, default=ROOT / 'yolov5s.pt', help='model.pt path(s)')
     parser.add_argument('--num-export-samples', type=int, default=0, help='number of sample inputs/outputs to export')
     parser.add_argument('--imgsz', '--img', '--img-size', nargs='+', type=int, default=[640, 640], help='image (h, w)')

--- a/train.py
+++ b/train.py
@@ -67,8 +67,8 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
           device,
           callbacks
           ):
-    save_dir, epochs, batch_size, weights, single_cls, evolve, data, cfg, resume, noval, nosave, workers, freeze = \
-        Path(opt.save_dir), opt.epochs, opt.batch_size, opt.weights, opt.single_cls, opt.evolve, opt.data, opt.cfg, \
+    save_dir, epochs, batch_size, weights, single_cls, evolve, data, data_path, cfg, resume, noval, nosave, workers, freeze = \
+        Path(opt.save_dir), opt.epochs, opt.batch_size, opt.weights, opt.single_cls, opt.evolve, opt.data, opt.data_path, opt.cfg, \
         opt.resume, opt.noval, opt.nosave, opt.workers, opt.freeze
 
     # Directories
@@ -108,7 +108,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     half_precision = cuda
     init_seeds(1 + RANK)
     with torch_distributed_zero_first(LOCAL_RANK):
-        data_dict = data_dict or check_dataset(data)  # check if None
+        data_dict = data_dict or check_dataset(data, data_path)  # check if None
     train_path, val_path = data_dict['train'], data_dict['val']
     nc = 1 if single_cls else int(data_dict['nc'])  # number of classes
     names = ['item'] if single_cls and len(data_dict['names']) != 1 else data_dict['names']  # class names
@@ -545,6 +545,7 @@ def parse_opt(known=False, skip_parse=False):
     parser.add_argument('--weights', type=str, default=ROOT / 'yolov5s.pt', help='initial weights path')
     parser.add_argument('--cfg', type=str, default='', help='model.yaml path')
     parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='dataset.yaml path')
+    parser.add_argument('--data-path', type=str, default= '', help='path to dataset to overwrite the path in dataset.yaml')
     parser.add_argument('--hyp', type=str, default=ROOT / 'data/hyps/hyp.scratch-low.yaml', help='hyperparameters path')
     parser.add_argument('--epochs', type=int, default=300)
     parser.add_argument('--batch-size', type=int, default=16, help='total batch size for all GPUs, -1 for autobatch')

--- a/utils/general.py
+++ b/utils/general.py
@@ -436,7 +436,7 @@ def check_font(font=FONT):
         torch.hub.download_url_to_file(url, str(font), progress=False)
 
 
-def check_dataset(data, autodownload=True):
+def check_dataset(data, data_path = '', autodownload=True):
     # Download and/or unzip dataset if not found locally
     # Usage: https://github.com/ultralytics/yolov5/releases/download/v1.0/coco128_with_yaml.zip
 
@@ -451,6 +451,8 @@ def check_dataset(data, autodownload=True):
     if isinstance(data, (str, Path)):
         with open(data, errors='ignore') as f:
             data = yaml.safe_load(f)  # dictionary
+            if data_path and 'path' in data:
+                data['path'] = data_path
 
     # Resolve paths
     path = Path(extract_dir or data.get('path') or '')  # optional 'path' default to '.'

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -35,7 +35,7 @@ def check_wandb_config_file(data_config_file):
     return data_config_file
 
 
-def check_wandb_dataset(data_file):
+def check_wandb_dataset(data_file, data_path):
     is_trainset_wandb_artifact = False
     is_valset_wandb_artifact = False
     if check_file(data_file) and data_file.endswith('.yaml'):
@@ -48,7 +48,7 @@ def check_wandb_dataset(data_file):
     if is_trainset_wandb_artifact or is_valset_wandb_artifact:
         return data_dict
     else:
-        return check_dataset(data_file)
+        return check_dataset(data_file, data_path)
 
 
 def get_run_info(run_path):
@@ -174,9 +174,9 @@ class WandbLogger():
                     if isinstance(opt.resume, str) and opt.resume.startswith(WANDB_ARTIFACT_PREFIX):
                         self.data_dict = dict(self.wandb_run.config.data_dict)
                     else:  # local resume
-                        self.data_dict = check_wandb_dataset(opt.data)
+                        self.data_dict = check_wandb_dataset(opt.data, opt.data_path)
                 else:
-                    self.data_dict = check_wandb_dataset(opt.data)
+                    self.data_dict = check_wandb_dataset(opt.data, opt.data_path)
                     self.wandb_artifact_data_dict = self.wandb_artifact_data_dict or self.data_dict
 
                     # write data_dict to config. useful for resuming from artifacts. Do this only when not resuming.

--- a/val.py
+++ b/val.py
@@ -96,6 +96,7 @@ def process_batch(detections, labels, iouv):
 
 @torch.no_grad()
 def run(data,
+        data_path='', # optional data path to overwrite one written in .yaml data file
         weights=None,  # model.pt path(s)
         batch_size=32,  # batch size
         imgsz=640,  # inference size (pixels)
@@ -151,7 +152,7 @@ def run(data,
                 LOGGER.info(f'Forcing --batch-size 1 square inference (1,3,{imgsz},{imgsz}) for non-PyTorch models')
 
         # Data
-        data = check_dataset(data)  # check
+        data = check_dataset(data, data_path)  # check
 
     # Configure
     model.eval()

--- a/val_onnx.py
+++ b/val_onnx.py
@@ -187,6 +187,7 @@ def get_stride(yolo_pipeline: Pipeline) -> int:
 @torch.no_grad()
 def run(
     data,
+    data_path='', # optional data path to overwrite one written in .yaml data file
     model_path=None,  # model.onnx path/ SparseZoo stub
     batch_size=32,  # batch size
     imgsz=640,  # inference size (pixels)
@@ -239,7 +240,7 @@ def run(
     imgsz = check_img_size(imgsz, s=stride)  # check image size
 
     # Data
-    data = check_dataset(data)  # check
+    data = check_dataset(data, data_path)  # check
 
     # Configure
     # Note: Only coco validation data is supported for now


### PR DESCRIPTION
This PR adds the optional arg `--data-path` to all yolov5 run paths that have the `--data` arg. The purpose of `--data-path` is to give users the ability to overwrite the actual path of the data directory that's written into the .yaml file that `--data` points to. This covers the use case of being able to run sparseml.yolov5 in a different directory without have to re-download the dataset. Since the upstream yolov5 is meant to be run directory from source, this is an issue unique to the nm fork, which is installable.

**Testing**
`make testinteg TARGETS=yolov5`
`SPARSEML_TEST_CADENCE=commit testinteg TARGETS=yolov5`
`sparseml.yolov5.train --epochs 1`
`sparseml.yolov5.train --epochs 1 --data coco128.yaml --data-path path_to_different_data_directory/coco128`
`sparseml.yolov5.export_onnx --num-export-samples 10`
`sparseml.yolov5.export_onnx --num-export-samples 10 --data coco128.yaml --data-path path_to_different_data_directory/coco128`
`sparseml.yolov5.validation --data coco128.yaml`
`sparseml.yolov5.validation --data coco128.yaml --data-path path_to_different_data_directory/coco128`
`sparseml.yolov5.val_onnx --data coco128.yaml`
`sparseml.yolov5.val_onnx --data coco128.yaml --data-path path_to_different_data_directory/coco128`

