### PR TITLE
Use last checkpoint for post training validation

### DIFF
--- a/train.py
+++ b/train.py
@@ -513,12 +513,12 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
         for f in last, best:
             if f.exists():
                 strip_optimizer(f)  # strip optimizers
-                if f is best:
+                if f is last:
                     LOGGER.info(f'\nValidating {f}...')
                     results, _, _ = val.run(data_dict,
                                             batch_size=batch_size // WORLD_SIZE * 2,
                                             imgsz=imgsz,
-                                            model=load_checkpoint(type_='ensemble', weights=best, device=device)[0],
+                                            model=load_checkpoint(type_='ensemble', weights=last, device=device)[0],
                                             iou_thres=0.65 if is_coco else 0.60,  # best pycocotools results at 0.65
                                             single_cls=single_cls,
                                             dataloader=val_loader,


### PR DESCRIPTION
Currently the best model is used for post training validation. This doesn't align with the sparseml flow, where the last model is typically used. This also causes issues when the model is quantized as the best model may not be quantized and will cause an import issue, as the model load code expects a quantized model dictionary. This PR provides a simple fix for the issue.

**Testing**
`make testinteg TARGETS=yolov5
``sparseml.yolov5.train --cfg models/yolov5n.yaml --data coco.yaml --batch-size 64 --recipe recipe_lr1em6.yaml --hyp data/hyps/hyp.scratch-low.yaml --weights yolov5n.pt --patience 0`

