### PR TITLE
By default, drop last for deepsparse val

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -97,7 +97,7 @@ def exif_transpose(image):
 
 
 def create_dataloader(path, imgsz, batch_size, stride, single_cls=False, hyp=None, augment=False, cache=False, pad=0.0,
-                      rect=False, rank=-1, workers=8, image_weights=False, quad=False, prefix='', shuffle=False):
+                      rect=False, rank=-1, workers=8, image_weights=False, quad=False, prefix='', shuffle=False, drop_last=False):
     if rect and shuffle:
         LOGGER.warning('WARNING: --rect is incompatible with DataLoader shuffle, setting shuffle=False')
         shuffle = False
@@ -124,6 +124,7 @@ def create_dataloader(path, imgsz, batch_size, stride, single_cls=False, hyp=Non
                   num_workers=nw,
                   sampler=sampler,
                   pin_memory=True,
+                  drop_last=drop_last,
                   collate_fn=LoadImagesAndLabels.collate_fn4 if quad else LoadImagesAndLabels.collate_fn), dataset
 
 

--- a/val_onnx.py
+++ b/val_onnx.py
@@ -266,7 +266,7 @@ def run(
         pad=pad,
         rect=rect,
         workers=1,
-        # workers=workers,
+        drop_last=True,
         prefix=colorstr(f"{task}: "),
     )[0]
 


### PR DESCRIPTION
This PR changes the default dataloader behavior for val_onnx to `drop_last=True`, so that the pipeline is fed a consistent batch size for validation.

**Testing**
`sparseml.yolov5.val_onnx --batch_size 3`
`make testinteg TARGETS=yolov5`