### PR TITLE
Add missing data path args

### DIFF
--- a/val.py
+++ b/val.py
@@ -330,6 +330,7 @@ def run(data,
 def parse_opt(known= False):
     parser = argparse.ArgumentParser()
     parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='dataset.yaml path')
+    parser.add_argument('--data-path', type=str, default= '', help='path to dataset to overwrite the path in dataset.yaml')
     parser.add_argument('--weights', nargs='+', type=str, default=ROOT / 'yolov5s.pt', help='model.pt path(s)')
     parser.add_argument('--batch-size', type=int, default=32, help='batch size')
     parser.add_argument('--imgsz', '--img', '--img-size', type=int, default=640, help='inference size (pixels)')

--- a/val_onnx.py
+++ b/val_onnx.py
@@ -481,6 +481,12 @@ def parse_opt():
     parser.add_argument(
         "--data", type=str, default=ROOT / "data/coco128.yaml", help="dataset.yaml path"
     )
+    parser.add_argument(
+        '--data-path', 
+        type=str, 
+        default= '', 
+        help='path to dataset to overwrite the path in dataset.yaml'
+    )
     default_yolo_stub = (
         "zoo:cv/detection/yolov5-l/pytorch/ultralytics/coco/pruned-aggressive_98"
     )


### PR DESCRIPTION
This PR adds the missing `--data-path` args to `val.py` and `val_onnx.py`