### PR TITLE
Save multiple best models

### DIFF
--- a/utils/sparse.py
+++ b/utils/sparse.py
@@ -210,10 +210,12 @@ class SparseMLWrapper(object):
 
         pruning_start = math.floor(max([mod.start_epoch for mod in self.manager.pruning_modifiers])) \
             if self.manager.pruning_modifiers else None
+        pruning_end = math.ceil(max([mod.end_epoch for mod in self.manager.pruning_modifiers])) \
+            if self.manager.pruning_modifiers else None
         qat_start = math.floor(max([mod.start_epoch for mod in self.manager.quantization_modifiers])) \
             if self.manager.quantization_modifiers else None
 
-        if pruning_start and epoch >= pruning_start:
+        if pruning_start and pruning_start <= epoch < pruning_end:
             save_name_suffixes.append("best_pruned")
 
         if qat_start and epoch >= qat_start:

--- a/utils/sparse.py
+++ b/utils/sparse.py
@@ -203,10 +203,10 @@ class SparseMLWrapper(object):
     def get_best_save_names(self, epoch):
         # return a list of the names to save a "best" model under
 
-        save_name_suffixes = ["best_overall"]
+        save_names = ["best_overall"]
 
         if not self.enabled:
-            return save_name_suffixes
+            return save_names
 
         pruning_start = math.floor(max([mod.start_epoch for mod in self.manager.pruning_modifiers])) \
             if self.manager.pruning_modifiers else None
@@ -215,16 +215,16 @@ class SparseMLWrapper(object):
         qat_start = math.floor(max([mod.start_epoch for mod in self.manager.quantization_modifiers])) \
             if self.manager.quantization_modifiers else None
 
-        if pruning_start and pruning_start <= epoch < pruning_end:
-            save_name_suffixes.append("best_pruned")
+        if pruning_start and pruning_start <= epoch and (epoch < pruning_end or qat_start is None):
+            save_names.append("best_pruned")
 
         if qat_start and epoch >= qat_start:
             if pruning_start and pruning_start <= epoch:
-                save_name_suffixes.append("best_pruned_quantized")
+                save_names.append("best_pruned_quantized")
             else:
-                save_name_suffixes.append("best_quantized")
+                save_names.append("best_quantized")
 
-        return save_name_suffixes
+        return save_names
 
     def _get_data_loader_builder(
         self, train_loader, device, multi_scale, img_size, grid_size

--- a/utils/sparse.py
+++ b/utils/sparse.py
@@ -215,11 +215,21 @@ class SparseMLWrapper(object):
         qat_start = math.floor(max([mod.start_epoch for mod in self.manager.quantization_modifiers])) \
             if self.manager.quantization_modifiers else None
 
-        if pruning_start and pruning_start <= epoch and (epoch < pruning_end or qat_start is None):
+        if (
+            pruning_start is not None
+            and pruning_start <= epoch 
+            and (epoch < pruning_end or qat_start is None)
+        ):
             save_names.append("best_pruned")
 
-        if qat_start and epoch >= qat_start:
-            if pruning_start and pruning_start <= epoch:
+        if (
+            qat_start is not None
+            and epoch >= qat_start
+        ):
+            if (
+                pruning_start is not None
+                and pruning_start <= epoch
+            ):
                 save_names.append("best_pruned_quantized")
             else:
                 save_names.append("best_quantized")


### PR DESCRIPTION
This PR adds automatic saving of best models for each of pruning, quantization,  pruning + quantization, and best overall. They are saved with the following file names and criteria:

**best_pruned.pt** - best model produced during pruning epochs. If quantization is present, not tracked during post-pruning quantization. Otherwise tracked to end of run (i.e. post-pruning fine tuning epochs will be candidates)
**best_quantized.pt** - best model produced after start of quantization, in a run with no pruning modifiers in recipe. 
**best_pruned_quantized.pt** - best model produced after start of quantization, in a run with a pruning modifier in the recipe.
**best_overall.pt** - best model produced at any epoch of the run

**Testing**
Integration tests + custom test command and recipe:
 sparseml.yolov5.train --cfg models_v5.0/yolov5s.yaml --weights yolov5s.pt --recipe recipes/yolov5_test_recipe.md --hyp data/hyps/hyp.scratch.yaml

Where yolov5_test_recipe.md is:

```
---
# General Hyperparams
num_epochs: 10
init_lr: 0.01
final_lr: 0.002
weights_warmup_lr: 0
biases_warmup_lr: 0.1
quantization_lr: 0.000002

# Pruning Hyperparams
init_sparsity: 0.05
pruning_start_epoch: 2
pruning_end_epoch: 8
pruning_update_frequency: 0.2
mask_type: [1, 4]
prune_none_target_sparsity: 0.4
prune_low_target_sparsity: 0.5
prune_mid_target_sparsity: 0.65
prune_high_target_sparsity: 0.75

# Quantization Params
quantization_start_epoch: 8

training_modifiers:
  - !EpochRangeModifier
    start_epoch: 0
    end_epoch: eval(num_epochs)
    
  - !LearningRateFunctionModifier
    start_epoch: 3
    end_epoch: eval(num_epochs)
    lr_func: cosine
    init_lr: eval(init_lr)
    final_lr: eval(final_lr)
     
  - !LearningRateFunctionModifier
    start_epoch: 0
    end_epoch: 3
    lr_func: linear
    init_lr: eval(biases_warmup_lr)
    final_lr: eval(init_lr)
    param_groups: [2]
    
  - !SetLearningRateModifier
    start_epoch: eval(quantization_start_epoch)
    learning_rate: eval(quantization_lr)
    
pruning_modifiers:
  - !GMPruningModifier
    params:
      - model.2.cv2.conv.weight
      - model.2.cv1.conv.weight
      - model.2.cv3.conv.weight
      - model.2.m.0.cv1.conv.weight
      - model.24.m.0.weight
      - model.24.m.1.weight
      - model.24.m.2.weight
    init_sparsity: eval(init_sparsity)
    final_sparsity: eval(prune_none_target_sparsity)
    start_epoch: eval(pruning_start_epoch)
    end_epoch: eval(pruning_end_epoch)
    update_frequency: eval(pruning_update_frequency)
    mask_type: eval(mask_type)
        
  - !GMPruningModifier
    params:
      - model.6.cv1.conv.weight
      - model.6.cv2.conv.weight
      - model.6.cv3.conv.weight
      - model.13.m.0.cv1.conv.weight
      - model.6.m.0.cv1.conv.weight
      - model.6.m.2.cv1.conv.weight
      - model.6.m.1.cv1.conv.weight
      - model.1.conv.weight
      - model.17.m.0.cv1.conv.weight
      - model.4.cv2.conv.weight
      - model.2.m.0.cv2.conv.weight
      - model.4.cv1.conv.weight
      - model.4.cv3.conv.weight
      - model.4.m.0.cv1.conv.weight
      - model.4.m.2.cv1.conv.weight
      - model.4.m.1.cv1.conv.weight
      - model.8.cv1.conv.weight
    init_sparsity: eval(init_sparsity)
    final_sparsity: eval(prune_low_target_sparsity)
    start_epoch: eval(pruning_start_epoch)
    end_epoch: eval(pruning_end_epoch)
    update_frequency: eval(pruning_update_frequency)
    mask_type: eval(mask_type)
        
  - !GMPruningModifier
    params:
      - model.9.cv3.conv.weight
      - model.6.m.2.cv2.conv.weight
      - model.5.conv.weight
      - model.9.cv1.conv.weight
      - model.6.m.1.cv2.conv.weight
      - model.6.m.0.cv2.conv.weight
      - model.17.m.0.cv2.conv.weight
      - model.9.cv2.conv.weight
      - model.10.conv.weight
      - model.13.cv2.conv.weight
      - model.9.m.0.cv1.conv.weight
      - model.20.m.0.cv1.conv.weight
      - model.13.cv3.conv.weight
      - model.13.cv1.conv.weight
      - model.17.cv3.conv.weight
      - model.14.conv.weight
      - model.4.m.2.cv2.conv.weight
      - model.3.conv.weight
      - model.4.m.1.cv2.conv.weight
      - model.4.m.0.cv2.conv.weight
      - model.17.cv1.conv.weight
      - model.23.m.0.cv1.conv.weight
      - model.20.cv1.conv.weight
      - model.23.cv1.conv.weight
    init_sparsity: eval(init_sparsity)
    final_sparsity: eval(prune_mid_target_sparsity)
    start_epoch: eval(pruning_start_epoch)
    end_epoch: eval(pruning_end_epoch)
    update_frequency: eval(pruning_update_frequency)
    mask_type: eval(mask_type)
        
  - !GMPruningModifier
    params:
      - model.23.m.0.cv2.conv.weight
      - model.21.conv.weight
      - model.23.cv3.conv.weight
      - model.23.cv2.conv.weight
      - model.20.m.0.cv2.conv.weight
      - model.18.conv.weight
      - model.9.m.0.cv2.conv.weight
      - model.7.conv.weight
      - model.20.cv3.conv.weight
      - model.20.cv2.conv.weight
      - model.8.cv2.conv.weight
      - model.13.m.0.cv2.conv.weight
      - model.17.cv2.conv.weight
    init_sparsity: eval(init_sparsity)
    final_sparsity: eval(prune_high_target_sparsity)
    start_epoch: eval(pruning_start_epoch)
    end_epoch: eval(pruning_end_epoch)
    update_frequency: eval(pruning_update_frequency)
    mask_type: eval(mask_type)
             
quantization_modifiers:
  - !QuantizationModifier
    start_epoch: eval(quantization_start_epoch)
    submodules: [ 'model.0', 'model.1', 'model.2', 'model.3', 'model.4', 'model.5', 'model.6', 'model.7', 'model.8', 'model.9', 'model.10', 'model.11', 'model.12', 'model.13', 'model.14', 'model.15', 'model.16', 'model.17', 'model.18', 'model.19', 'model.20', 'model.21', 'model.22', 'model.23' ]

---
```
