### PR TITLE
pathway to save sample inputs as uint8 for onnx graphs with uint8 inputs

### DIFF
--- a/export.py
+++ b/export.py
@@ -690,6 +690,7 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
             num_export_samples=num_export_samples,
             save_dir= os.path.dirname(file),
             image_size=imgsz,
+            save_inputs_as_uint8=f[2] and _graph_has_uint8_inputs(f[2])
         )
 
     # TensorFlow Exports
@@ -770,6 +771,13 @@ def parse_opt(known = False, skip_parse = False):
     
     print_args(FILE.stem, opt)
     return opt
+
+
+def _graph_has_uint8_inputs(onnx_path):
+    import onnx
+    onnx_model = onnx.load(onnx_path)
+    # check if first model input has elem type 2 (uint8)
+    return onnx_model.graph.input[0].type.tensor_type.elem_type == 2
 
 
 def main(opt):

--- a/utils/sparse.py
+++ b/utils/sparse.py
@@ -310,7 +310,7 @@ class SparseMLWrapper(object):
 
                 sample_input_filename = os.path.join(f"{sample_in_dir}", f"inp-{file_idx}.npz")
                 if save_inputs_as_uint8:
-                    sample_in = (255 * sample_in).astype(numpy.uint8)
+                    sample_in = (255 * sample_in).to(dtype=torch.uint8)
                 numpy.savez(sample_input_filename, sample_in)
 
                 sample_output_filename = os.path.join(f"{sample_out_dir}", f"out-{file_idx}.npz")

--- a/utils/sparse.py
+++ b/utils/sparse.py
@@ -266,6 +266,7 @@ class SparseMLWrapper(object):
         num_export_samples=100,
         save_dir: Optional[str] = None,
         image_size: int=640,
+        save_inputs_as_uint8: bool = False,
    ):
         save_dir = save_dir or ""
         if not dataloader:
@@ -308,6 +309,8 @@ class SparseMLWrapper(object):
                 file_idx = f"{exported_samples}".zfill(4)
 
                 sample_input_filename = os.path.join(f"{sample_in_dir}", f"inp-{file_idx}.npz")
+                if save_inputs_as_uint8:
+                    sample_in = (255 * sample_in).astype(numpy.uint8)
                 numpy.savez(sample_input_filename, sample_in)
 
                 sample_output_filename = os.path.join(f"{sample_out_dir}", f"out-{file_idx}.npz")


### PR DESCRIPTION
adds a quick check if an exported onnx graph requires uint8 inputs and adds a pathway to convert inputs back to uint8

**test plan**
manual via research team