### PR TITLE
Set multi_label to always true for val_onnx pipeline

### DIFF
--- a/val_onnx.py
+++ b/val_onnx.py
@@ -310,7 +310,10 @@ def run(
 
         # Inference
         out = yolo_pipeline(
-            images=[im.numpy()], iou_thres=iou_thres, conf_thres=conf_thres
+            images=[im.numpy()], 
+            iou_thres=iou_thres, 
+            conf_thres=conf_thres, 
+            multi_label=True
         )
 
         # inference, loss outputs


### PR DESCRIPTION
multi_label is true by default in val.py. This PR updates val_onnx.py to mimic the behavior and produce closer to identical results. 