### PR TITLE
Add relative data pathing to export script

### DIFF
--- a/export.py
+++ b/export.py
@@ -68,7 +68,7 @@ from models.experimental import attempt_load
 from models.yolo import Detect, Model
 from utils.activations import SiLU
 from utils.datasets import LoadImages
-from utils.general import (LOGGER, ROOT, check_dataset, check_img_size, check_requirements, check_version, colorstr,
+from utils.general import (LOGGER, ROOT, check_dataset, check_file, check_img_size, check_requirements, check_version, colorstr,
                            file_size, print_args, url2file, intersect_dicts)
 from utils.torch_utils import select_device, torch_distributed_zero_first, is_parallel
 from utils.downloads import attempt_download
@@ -624,6 +624,7 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
     assert sum(flags) == len(include), f'ERROR: Invalid --include {include}, valid --include arguments are {formats}'
     jit, onnx, xml, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs = flags  # export booleans
     file = Path(url2file(weights) if str(weights).startswith(('http:/', 'https:/')) else weights)  # PyTorch weights
+    data = check_file(data)
 
     # Load PyTorch model
     device = select_device(device)


### PR DESCRIPTION
Currently, running export with data will fail if the relative pathing to the .yaml file isn't correct. This is because the data arg pre-processing native to the train script isn't utilized in the export script. This PR patches that issue

**Testing Plan**
`sparseml.yolov5.export_onnx --dynamic --data data/VOC.yaml --data-path ~/datasets/voc --num-export-samples 20 --weights /home/ubuntu/source/sparseml/yolov5s.pt`