### PR TITLE
Rescale batch for autobatch + QAT

### DIFF
--- a/train.py
+++ b/train.py
@@ -232,12 +232,13 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
     mlc = int(labels[:, 0].max())  # max label class
     assert mlc < nc, f'Label class {mlc} exceeds nc={nc} in {data}. Possible class labels are 0-{nc - 1}'
 
-    if not resume:
-        if not opt.noautoanchor:
-            check_anchors(dataset, model=model, thr=hyp['anchor_t'], imgsz=imgsz)  # run AutoAnchor
-        model.half().float()  # pre-reduce anchor precision
+    if RANK in {-1, 0}:
+        if not resume:
+            if not opt.noautoanchor:
+                check_anchors(dataset, model=model, thr=hyp['anchor_t'], imgsz=imgsz)  # run AutoAnchor
+            model.half().float()  # pre-reduce anchor precision
 
-    callbacks.run('on_pretrain_routine_end', labels, names)
+        callbacks.run('on_pretrain_routine_end', labels, names)
 
     # DDP mode
     if cuda and RANK != -1:

--- a/utils/neural_magic/sparse_train_manager.py
+++ b/utils/neural_magic/sparse_train_manager.py
@@ -214,6 +214,13 @@ class SparseTrainManager(object):
         # the original effective batch size. Note that if the original batch size is odd
         # then the effective batch size will be incremented by 1
         batch_size = batch_size if batch_size % 2 == 0 else batch_size + 1
+        batch_size_ratio = math.floor(batch_size / new_batch_size)
+        closest_divisor = next(
+            divisor
+            for divisor in range(batch_size_ratio, 1, -1)
+            if batch_size % divisor == 0
+        )
+        new_batch_size = batch_size // closest_divisor
         new_accumulate = math.floor((batch_size * accumulate) // new_batch_size)
         new_batch_size = batch_size // new_accumulate
 

--- a/utils/neural_magic/sparse_train_manager.py
+++ b/utils/neural_magic/sparse_train_manager.py
@@ -214,14 +214,8 @@ class SparseTrainManager(object):
         # the original effective batch size. Note that if the original batch size is odd
         # then the effective batch size will be incremented by 1
         batch_size = batch_size if batch_size % 2 == 0 else batch_size + 1
-        batch_size_ratio = math.floor(batch_size / new_batch_size)
-        closest_divisor = next(
-            divisor
-            for divisor in range(batch_size_ratio, 1, -1)
-            if batch_size % divisor == 0
-        )
-        new_batch_size = batch_size // closest_divisor
-        new_accumulate = (batch_size * accumulate) // new_batch_size
+        new_accumulate = math.floor((batch_size * accumulate) // new_batch_size)
+        new_batch_size = batch_size // new_accumulate
 
         self.log_console_info(
             f"Batch size rescaled to {new_batch_size} with {new_accumulate} gradient "

--- a/utils/neural_magic/sparse_train_manager.py
+++ b/utils/neural_magic/sparse_train_manager.py
@@ -1,14 +1,17 @@
+import math
 import os
+from copy import deepcopy
 from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
 from sparseml.pytorch.optim import ScheduledModifierManager
 from sparseml.pytorch.utils import SparsificationGroupLogger
 
+from utils.autobatch import check_train_batch_size
 from utils.general import colorstr
 from utils.loggers import Loggers
 from utils.neural_magic.utils import load_ema
-from utils.torch_utils import ModelEMA
+from utils.torch_utils import ModelEMA, de_parallel
 
 __all__ = ["SparseTrainManager", "maybe_load_sparse_model"]
 
@@ -190,6 +193,49 @@ class SparseTrainManager(object):
         :param scaler: scaler to run off
         """
         scaler._enabled = False
+
+    def rescale_gradient_accumulation(
+        self, batch_size: int, accumulate: int, image_size: int
+    ) -> Tuple[int, int]:
+        """
+        Used when autobatch and QAT are both enabled. Training with QAT adds additional
+        overhead which can cause OOM errors if autobatch is enabled. This function
+        rescales batch size and gradient accumulation to fit into memory with QAT while
+        maintaining the original effective batch size
+        """
+        # Temporary copy of the model with QAT applied
+        quant_model_copy = deepcopy(de_parallel(self.model))
+        self.train_manager.apply_structure(quant_model_copy, float("inf"))
+
+        # Calculate maximum batch size that will fit in memory
+        new_batch_size = check_train_batch_size(quant_model_copy, image_size, False)
+
+        # Calculate batch size closest to maximum that can be accumulated to maintain
+        # the original effective batch size. Note that if the original batch size is odd
+        # then the effective batch size will be incremented by 1
+        batch_size = batch_size if batch_size % 2 == 0 else batch_size + 1
+        batch_size_ratio = math.floor(batch_size / new_batch_size)
+        closest_divisor = next(
+            divisor
+            for divisor in range(batch_size_ratio, 1, -1)
+            if batch_size % divisor == 0
+        )
+        new_batch_size = batch_size // closest_divisor
+        new_accumulate = (batch_size * accumulate) // new_batch_size
+
+        self.log_console_info(
+            f"Batch size rescaled to {new_batch_size} with {new_accumulate} gradient "
+            "accumulation steps for QAT"
+        )
+
+        if new_accumulate * new_batch_size != batch_size * accumulate:
+            raise RuntimeError(
+                "New effective batch size doesn't match previous effective batch size. "
+                f"Previous batch size and accumulation: {[batch_size, accumulate]}. "
+                f"New batch size and accumulation: {[new_batch_size, new_accumulate]}"
+            )
+
+        return new_batch_size, new_accumulate
 
     def update_state_dict_for_saving(
         self, ckpt: Dict[str, Any], final_epoch: bool, ema_enabled: bool


### PR DESCRIPTION
This PR addresses OOM issues that can happen when autobatch and QAT are used together. Because autobatch calculates and sets the maximum batch size that can fit into memory, it will inevitably cause OOM issues if QAT is enabled, as QAT has additional memory overhead. 

The solution for this issue ended up being quite involved and includes modifications to base yolov5 code that I'm not fully comfortable with. I'd like us to consider alternatives, including hardcoding batch sizes to recipes until we start automatically including batch size in recipe metadata

**Testing Plan**
```
python3 train.py --weights zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/base-none --sparsification-recipe zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned_quant-aggressive_94
```
```
python3 train.py --cfg yolov5s.yaml --sparsification-recipe zoo:cv/detection/yolov5-s6/pytorch/ultralytics/coco/base_quant-none --batch-size -1
```