### PR TITLE
Add checks for bad run states

### DIFF
--- a/train.py
+++ b/train.py
@@ -449,7 +449,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
                 strip_optimizer(f) if not sparsification_manager else sparsification_manager.strip_sparsified_optimizer(f)  # strip optimizers
                 if f is best:
                     LOGGER.info(f'\nValidating {f}...')
-                    model = attempt_load(f, device, fuse=not sparsification_manager)
+                    model = attempt_load(f, device)
                     if amp:
                         model.half()
                     results, _, _ = validate.run(

--- a/train.py
+++ b/train.py
@@ -291,13 +291,12 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
         if sparsification_manager and sparsification_manager.starting_qat(epoch):
             ema, amp, scaler = sparsification_manager.disable_ema_amp(ema, amp, scaler)
             # Rescale batch size for QAT
-            if opt.batch_size == -1:
-                batch_size, accumulate = sparsification_manager.rescale_gradient_accumulation(
-                    batch_size=batch_size, 
-                    accumulate=accumulate, 
-                    image_size=imgsz
-                )
-                train_loader, dataset, val_loader = _create_dataloaders()
+            batch_size, accumulate = sparsification_manager.rescale_gradient_accumulation(
+                batch_size=batch_size, 
+                accumulate=accumulate, 
+                image_size=imgsz
+            )
+            train_loader, dataset, val_loader = _create_dataloaders()
 
         model.train()
 

--- a/train.py
+++ b/train.py
@@ -55,7 +55,7 @@ from utils.loggers import Loggers
 from utils.loggers.comet.comet_utils import check_comet_resume
 from utils.loss import ComputeLoss
 from utils.metrics import fitness
-from utils.neural_magic import sparsezoo_download, maybe_load_sparsified_model, SparsificationManager
+from utils.neuralmagic import sparsezoo_download, maybe_create_sparsification_manager, SparsificationManager, load_sparsified_model
 from utils.plots import plot_evolve
 from utils.torch_utils import (EarlyStopping, ModelEMA, de_parallel, select_device, smart_DDP, smart_optimizer,
                                smart_resume, torch_distributed_zero_first)
@@ -124,7 +124,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
             ) 
         ckpt = torch.load(weights, map_location='cpu')  # load checkpoint to CPU to avoid CUDA memory leak
         model = Model(cfg or ckpt.get('yaml') or ckpt['model'].yaml, ch=3, nc=nc, anchors=hyp.get('anchors')).to(device)  # create
-        sparse_manager = maybe_load_sparsified_model(model, ckpt=ckpt, train_recipe=opt.sparsification_recipe, recipe_args=opt.recipe_args) # process sparse model, if detected 
+        sparsification_manager = maybe_create_sparsification_manager(model, ckpt=ckpt, train_recipe=opt.sparsification_recipe, recipe_args=opt.recipe_args) # process sparse model, if detected 
         exclude = ['anchor'] if (cfg or hyp.get('anchors')) and not resume else []  # exclude keys
         csd = ckpt['model'].float().state_dict() if isinstance(ckpt['model'], nn.Module) else ckpt['model'] # checkpoint state_dict as FP32
         csd = intersect_dicts(csd, model.state_dict(), exclude=exclude)  # intersect
@@ -132,7 +132,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
         LOGGER.info(f'Transferred {len(csd)}/{len(model.state_dict())} items from {weights}')  # report
     else:
         model = Model(cfg, ch=3, nc=nc, anchors=hyp.get('anchors')).to(device)  # create
-        sparse_manager = (
+        sparsification_manager = (
             SparsificationManager(model, train_recipe=opt.sparsification_recipe, recipe_args=opt.recipe_args) 
             if opt.sparsification_recipe 
             else None
@@ -267,8 +267,8 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
     scaler = torch.cuda.amp.GradScaler(enabled=amp)
     stopper, stop = EarlyStopping(patience=opt.patience), False
     compute_loss = ComputeLoss(model)  # init loss class
-    if sparse_manager: # update run configuration for training-aware sparsification
-        scaler, scheduler, ema, epochs = sparse_manager.initialize(
+    if sparsification_manager: # update run configuration for training-aware sparsification
+        scaler, scheduler, ema, epochs = sparsification_manager.initialize(
             loggers=loggers,
             scaler=scaler,
             optimizer=optimizer,
@@ -288,11 +288,11 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
         callbacks.run('on_train_epoch_start')
 
         # Turn off features incompatible with QAT
-        if sparse_manager and sparse_manager.starting_qat(epoch):
-            sparse_manager.disable_ema_amp(ema, amp, scaler)
+        if sparsification_manager and sparsification_manager.starting_qat(epoch):
+            sparsification_manager.disable_ema_amp(ema, amp, scaler)
             # Rescale batch size for QAT
             if opt.batch_size == -1:
-                batch_size, accumulate = sparse_manager.rescale_gradient_accumulation(
+                batch_size, accumulate = sparsification_manager.rescale_gradient_accumulation(
                     batch_size=batch_size, 
                     accumulate=accumulate, 
                     image_size=imgsz
@@ -420,8 +420,8 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
                     'opt': vars(opt),
                     'date': datetime.now().isoformat()}
 
-                if sparse_manager:
-                    ckpt = sparse_manager.update_state_dict_for_saving(ckpt, final_epoch, ema.enabled)
+                if sparsification_manager:
+                    ckpt = sparsification_manager.update_state_dict_for_saving(ckpt, final_epoch, ema.enabled)
 
                 # Save last, best and delete
                 torch.save(ckpt, last)
@@ -443,18 +443,19 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
 
         # end epoch ----------------------------------------------------------------------------------------------------
     # end training -----------------------------------------------------------------------------------------------------
-    if RANK in {-1, 0} and not sparse_manager:
+    if RANK in {-1, 0}:
         LOGGER.info(f'\n{epoch - start_epoch + 1} epochs completed in {(time.time() - t0) / 3600:.3f} hours.')
         for f in last, best:
             if f.exists():
-                strip_optimizer(f)  # strip optimizers
+                strip_optimizer(f) if not sparsification_manager else sparsification_manager.strip_sparsified_optimizer(f)  # strip optimizers
                 if f is best:
                     LOGGER.info(f'\nValidating {f}...')
+                    model = attempt_load(f, device).half()
                     results, _, _ = validate.run(
                         data_dict,
                         batch_size=batch_size // WORLD_SIZE * 2,
                         imgsz=imgsz,
-                        model=attempt_load(f, device).half(),
+                        model=model,
                         iou_thres=0.65 if is_coco else 0.60,  # best pycocotools at iou 0.65
                         single_cls=single_cls,
                         dataloader=val_loader,

--- a/utils/neuralmagic/sparse_train_manager.py
+++ b/utils/neuralmagic/sparse_train_manager.py
@@ -265,6 +265,8 @@ class SparsificationManager(object):
         # the original effective batch size. Note that if the original batch size is odd
         # then the effective batch size will be incremented by 1
 
+        # Roughly calculate batch size by rounding. In many circumstances this can
+        # result in an effective batch size that is 1-few off from the original
         new_accumulate = round(batch_size / new_batch_size)
         new_batch_size = round(batch_size / new_accumulate)
 

--- a/utils/neuralmagic/sparse_train_manager.py
+++ b/utils/neuralmagic/sparse_train_manager.py
@@ -35,9 +35,9 @@ class SparsificationManager(object):
     def __init__(
         self,
         model: torch.nn.Module,
-        train_recipe: str,
+        train_recipe: Optional[str],
         recipe_args: Optional[Union[Dict[str, Any], str]],
-        checkpoint_recipe: str = None,
+        checkpoint_recipe: Optional[str] = None,
         last_epoch: int = 0,
     ):
         self.qat_started = False
@@ -64,7 +64,8 @@ class SparsificationManager(object):
 
         # Training manager for current training run
         self.train_manager = ScheduledModifierManager.from_yaml(
-            file_path=train_recipe, recipe_variables=recipe_args
+            file_path=train_recipe,
+            recipe_variables=recipe_args if train_recipe else None,
         )
 
         # Apply recipe structure from checkpoint recipe. Can include QAT and layer

--- a/utils/neuralmagic/sparse_train_manager.py
+++ b/utils/neuralmagic/sparse_train_manager.py
@@ -68,7 +68,7 @@ class SparsificationManager(object):
                 file_path=train_recipe, recipe_variables=recipe_args
             )
             if train_recipe
-            else None,
+            else None
         )
 
         # Apply recipe structure from checkpoint recipe. Can include QAT and layer
@@ -130,7 +130,8 @@ class SparsificationManager(object):
         Update objects controlling the training process for sparse training
         """
         # Wrap model for sparse training modifiers from recipe
-        self.train_manager.initialize(module=self.model, epoch=start_epoch)
+        if self.train_manager:
+            self.train_manager.initialize(module=self.model, epoch=start_epoch)
 
         # initialize SparseML loggers, including recipe modifier loggers
         self.initialize_loggers(loggers)

--- a/utils/neuralmagic/sparse_train_manager.py
+++ b/utils/neuralmagic/sparse_train_manager.py
@@ -63,9 +63,12 @@ class SparsificationManager(object):
         )
 
         # Training manager for current training run
-        self.train_manager = ScheduledModifierManager.from_yaml(
-            file_path=train_recipe,
-            recipe_variables=recipe_args if train_recipe else None,
+        self.train_manager = (
+            ScheduledModifierManager.from_yaml(
+                file_path=train_recipe, recipe_variables=recipe_args
+            )
+            if train_recipe
+            else None,
         )
 
         # Apply recipe structure from checkpoint recipe. Can include QAT and layer

--- a/utils/neuralmagic/sparse_train_manager.py
+++ b/utils/neuralmagic/sparse_train_manager.py
@@ -89,15 +89,15 @@ class SparsificationManager(object):
         if self.checkpoint_manager and self.checkpoint_manager.pruning_modifiers:
             if not self.train_manager:
                 self.log_console(
-                    "Model in danger of de-sparsification. Pruned model was loaded, "
-                    "but no sparsification recipe detected. A recipe with a "
+                    "Pruned model was loaded, but no sparsification recipe detected - "
+                    "model may revert to dense state. A recipe with a "
                     "ConstantPruningModifier can be used to maintain model sparsity "
                     "while training"
                 )
             elif not self.train_manager.pruning_modifiers:
                 self.log_console(
-                    "Model in danger of de-sparsification. Pruned model was loaded, "
-                    "but no pruning modifiers detected in sparsification recipe. A "
+                    "Pruned model was loaded, but no pruning modifiers detected in "
+                    "sparsification recipe - model may revert to dense state. A "
                     "recipe with a ConstantPruningModifier can be used to maintain "
                     "model sparsity while training"
                 )
@@ -382,6 +382,7 @@ class SparsificationManager(object):
             f"Optimizer stripped from {checkpoint_path},"
             f"{f' saved as {save_name},' if save_name else ''} {megabytes:.1f}MB"
         )
+
 
 def maybe_create_sparsification_manager(
     model: torch.nn.Module,

--- a/utils/neuralmagic/sparse_train_manager.py
+++ b/utils/neuralmagic/sparse_train_manager.py
@@ -17,8 +17,6 @@ __all__ = ["SparsificationManager", "maybe_create_sparsification_manager"]
 
 RANK = int(os.getenv("RANK", -1))
 
-# TODO: quantize add
-
 
 class SparsificationManager(object):
     """

--- a/utils/neuralmagic/sparse_train_manager.py
+++ b/utils/neuralmagic/sparse_train_manager.py
@@ -231,7 +231,7 @@ class SparsificationManager(object):
 
     def disable_ema_amp(
         self, ema: ToggleableModelEMA, amp: bool, scaler: torch.cuda.amp.GradScaler
-    ):
+    ) -> Tuple[ToggleableModelEMA, bool, torch.cuda.amp.GradScaler]:
         """
         Disable EMA and AMP if active, as they're not compatible with QAT
         """
@@ -243,6 +243,8 @@ class SparsificationManager(object):
             self.log_console("Turning off AMP (not supported with QAT)")
             amp = False
             scaler._enabled = False
+
+        return ema, amp, scaler
 
     def rescale_gradient_accumulation(
         self, batch_size: int, accumulate: int, image_size: int

--- a/utils/neuralmagic/utils.py
+++ b/utils/neuralmagic/utils.py
@@ -58,8 +58,7 @@ def load_sparsified_model(
 ) -> torch.nn.Module:
     """
     From a sparisifed checkpoint, loads a model with the saved weights and
-    sparsification recipe applied. Fulfills the same function as
-    models.experimental.attempt_load() for sparsified checkpoints
+    sparsification recipe applied
 
     :param ckpt: either a loaded checkpoint or the path to a saved checkpoint
     :param device: device to load the model onto

--- a/utils/neuralmagic/utils.py
+++ b/utils/neuralmagic/utils.py
@@ -74,5 +74,5 @@ def load_sparsified_model(
     )
 
     # Load state dict
-    model.load_state_dict(ckpt["ema"] or ckpt["model"], strict=True).half()
+    model.load_state_dict(ckpt["ema"] or ckpt["model"], strict=True)
     return model

--- a/utils/neuralmagic/utils.py
+++ b/utils/neuralmagic/utils.py
@@ -1,12 +1,19 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 import torch
+from sparseml.pytorch.optim import ScheduledModifierManager
 from sparseml.pytorch.utils import download_framework_model_by_recipe_type
 from sparsezoo import Model
 
+from models.yolo import Model as Yolov5Model
 from utils.torch_utils import ModelEMA
 
-__all__ = ["sparsezoo_download", "ToggleableModelEMA", "load_ema"]
+__all__ = [
+    "sparsezoo_download",
+    "ToggleableModelEMA",
+    "load_ema",
+    "load_sparsified_model",
+]
 
 
 class ToggleableModelEMA(ModelEMA):
@@ -23,7 +30,7 @@ class ToggleableModelEMA(ModelEMA):
             super().update(*args, **kwargs)
 
 
-def sparsezoo_download(path: str, sparsification_recipe: Optional[str]) -> str:
+def sparsezoo_download(path: str, sparsification_recipe: Optional[str] = None) -> str:
     """
     Loads model from the SparseZoo and override the path with the new download path
     """
@@ -44,3 +51,29 @@ def load_ema(
     ema = ToggleableModelEMA(enabled, model, **ema_kwargs)
     ema.ema.load_state_dict(ema_state_dict)
     return ema
+
+
+def load_sparsified_model(
+    ckpt: Union[Dict[str, Any], str], device: Union[str, torch.device] = "cpu"
+) -> torch.nn.Module:
+    """
+    From a sparisifed checkpoint, loads a model with the saved weights and
+    sparsification recipe applied. Fulfills the same function as
+    models.experimental.attempt_load() for sparsified checkpoints
+
+    :param ckpt: either a loaded checkpoint or the path to a saved checkpoint
+    :param device: device to load the model onto
+    """
+    # Load checkpoint if not yet loaded
+    ckpt = ckpt if isinstance(ckpt, dict) else torch.load(ckpt, map_location=device)
+
+    # Construct randomly initialized model model and apply sparse structure modifiers
+    model = Yolov5Model(ckpt.get("yaml")).to(device)
+    checkpoint_manager = ScheduledModifierManager.from_yaml(ckpt["checkpoint_recipe"])
+    checkpoint_manager.apply_structure(
+        model, ckpt["epoch"] if ckpt["epoch"] >= 0 else float("inf")
+    )
+
+    # Load state dict
+    model.load_state_dict(ckpt["ema"] or ckpt["model"], strict=True).half()
+    return model


### PR DESCRIPTION
This PR adds coverage and checks for valid combinations of loaded checkpoints and training recipes.

Use cases covered:
- Manual batch size will now also trigger batch size re-calculation on QAT start
- Training from a pruned checkpoints without a recipe or without pruning modifiers in the recipe will now throw helpful warnings
- Training from a quantized checkpoint with a recipe with a quantization modifier will now throw an error, as multiple applications of QAT to a model is not supported

**Testing Plan**
```
python3 train.py --weights "zoo:cv/detection/yolov5-s6/pytorch/ultralytics/coco/base-none" --sparsification-recipe "zoo:cv/detection/yolov5-s6/pytorch/ultralytics/coco/base_quant-none" 
```
```
python3 train.py --weights "zoo:cv/detection/yolov5-s6/pytorch/ultralytics/coco/base_quant-none" --sparsification-recipe "zoo:cv/detection/yolov5-s6/pytorch/ultralytics/coco/base_quant-none" 
```
\+ manual local testing