### PR TITLE
One-shot sparsification

### DIFF
--- a/export.py
+++ b/export.py
@@ -151,7 +151,7 @@ def export_onnx(model, im, file, opset, dynamic, simplify, sparsified=False, dat
 
     if sparsified:
 
-        save_dir = f.parent / "DeepSparse_Deployment" # Update export directory
+        save_dir = f.parents[1] / "DeepSparse_Deployment" # Update export directory
         save_dir.mkdir(exist_ok=True)
         f = save_dir / f.name 
 

--- a/export.py
+++ b/export.py
@@ -73,6 +73,7 @@ from models.yolo import ClassificationModel, Detect, DetectionModel, Segmentatio
 from utils.dataloaders import LoadImages
 from utils.general import (LOGGER, Profile, check_dataset, check_img_size, check_requirements, check_version,
                            check_yaml, colorstr, file_size, get_default_args, print_args, url2file, yaml_save)
+from utils.neuralmagic import apply_recipe_one_shot, get_sample_data
 from utils.torch_utils import select_device, smart_inference_mode
 
 MACOS = platform.system() == 'Darwin'  # macOS environment
@@ -131,7 +132,7 @@ def export_torchscript(model, im, file, optimize, prefix=colorstr('TorchScript:'
 
 
 @try_export
-def export_onnx(model, im, file, opset, dynamic, simplify, sparsified=False, prefix=colorstr('ONNX:')):
+def export_onnx(model, im, file, opset, dynamic, simplify, sparsified=False, data=None, one_shot=None, prefix=colorstr('ONNX:')):
     # YOLOv5 ONNX export
     check_requirements('onnx')
     import onnx
@@ -149,6 +150,17 @@ def export_onnx(model, im, file, opset, dynamic, simplify, sparsified=False, pre
             dynamic['output0'] = {0: 'batch', 1: 'anchors'}  # shape(1,25200,85)
 
     if sparsified:
+
+        save_dir = f.parent / "DeepSparse_Deployment" # Update export directory
+        save_dir.mkdir(exist_ok=True)
+        f = save_dir / f.name 
+
+        if one_shot:
+            sparsification_manager = apply_recipe_one_shot(model, one_shot)
+            if data:
+                samples = get_sample_data(im, data)
+                torch.save(samples, save_dir / "input_samples.npy")
+
         exporter = ModuleExporter(model, f.parent.absolute())
         exporter.export_onnx(
             im,
@@ -158,6 +170,7 @@ def export_onnx(model, im, file, opset, dynamic, simplify, sparsified=False, pre
             output_names=output_names,
             dynamic_axes=dynamic or None
         )
+
 
     else:
         torch.onnx.export(
@@ -524,6 +537,7 @@ def run(
         topk_all=100,  # TF.js NMS: topk for all classes to keep
         iou_thres=0.45,  # TF.js NMS: IoU threshold
         conf_thres=0.25,  # TF.js NMS: confidence threshold
+        one_shot=None #sparsification recipe to apply on export
 ):
     t = time.time()
     include = [x.lower() for x in include]  # to lowercase
@@ -541,7 +555,7 @@ def run(
     model = attempt_load(weights, device=device, inplace=True, fuse=True)  # load FP32 model
 
     # Sparsified models must be exported with onnx
-    sparsified = getattr(model, "sparsified", False)
+    sparsified = getattr(model, "sparsified", False) or one_shot
     if sparsified:
         flags = [False] * len(fmts)
         flags[1] = True
@@ -581,7 +595,7 @@ def run(
     if engine:  # TensorRT required before ONNX
         f[1], _ = export_engine(model, im, file, half, dynamic, simplify, workspace, verbose)
     if onnx or xml:  # OpenVINO requires ONNX
-        f[2], _ = export_onnx(model, im, file, opset, dynamic, simplify, sparsified)
+        f[2], _ = export_onnx(model, im, file, opset, dynamic, simplify, sparsified, data, one_shot)
     if xml:  # OpenVINO
         f[3], _ = export_openvino(file, metadata, half)
     if coreml:  # CoreML
@@ -657,6 +671,12 @@ def parse_opt():
         nargs='+',
         default=['torchscript'],
         help='torchscript, onnx, openvino, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs, paddle')
+    parser.add_argument(
+        "--one-shot",
+        type=str,
+        default=None,
+        help="local path or SparseZoo stub to a recipe to be applied"
+                " in one-shot manner before exporting")
     opt = parser.parse_args()
     print_args(vars(opt))
     return opt

--- a/train.py
+++ b/train.py
@@ -338,7 +338,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
                 xi = [0, nw]  # x interp
                 # compute_loss.gr = np.interp(ni, xi, [0.0, 1.0])  # iou loss ratio (obj_loss = 1.0 or iou)
                 accumulate = max(1, np.interp(ni, xi, [1, nbs / batch_size]).round())
-                for j, x in enumerate(optimizer.param_groups):
+                for j, x in enumerate(optimizer.param_groups[:3]): # distillation can add groups beyond the base 3
                     # bias lr falls from 0.1 to lr0, all other lrs rise from 0.0 to lr0
                     x['lr'] = np.interp(ni, xi, [hyp['warmup_bias_lr'] if j == 0 else 0.0, x['initial_lr'] * lf(epoch)])
                     if 'momentum' in x:
@@ -391,7 +391,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
             # end batch ------------------------------------------------------------------------------------------------
 
         # Scheduler
-        lr = [x['lr'] for x in optimizer.param_groups]  # for loggers
+        lr = [x['lr'] for x in optimizer.param_groups[:3]]  # for loggers. distillation can add groups beyond the base 3
         if scheduler:
             scheduler.step()
 


### PR DESCRIPTION
Support for one-shot sparsification and sample export

Rider - distillation can add additional param groups. Added a change that limits the params with lr updates to the 3 default yolov5 ones

**Testing Plan**
`python3 export.py --weights yolov5s6.pt --dynamic --one-shot test_quantize_recipe.md --export-samples 20`
Compare resulting graph manually and run through deepsparse