### PR TITLE
Fix for much larger autobatch

### DIFF
--- a/utils/neuralmagic/sparse_train_manager.py
+++ b/utils/neuralmagic/sparse_train_manager.py
@@ -358,8 +358,8 @@ class SparsificationManager(object):
 
         # Roughly calculate batch size by rounding. In many circumstances this can
         # result in an effective batch size that is 1-few off from the original
-        new_accumulate = round(batch_size / new_batch_size)
-        new_batch_size = round(batch_size / new_accumulate)
+        new_accumulate = max(round(batch_size / new_batch_size), 1)
+        new_batch_size = max(round(batch_size / new_accumulate), 1)
 
         self.log_console(
             f"Batch size rescaled to {new_batch_size} with {new_accumulate} gradient "


### PR DESCRIPTION
In the case of a small user defined batch size and QAT, the grad accum steps can come out to 0. This PR patches that issue