### PR TITLE
Increment epoch to apply recipe at by almost one

### DIFF
--- a/utils/neuralmagic/sparsification_manager.py
+++ b/utils/neuralmagic/sparsification_manager.py
@@ -11,7 +11,7 @@ from utils.autobatch import check_train_batch_size
 from utils.loggers import Loggers
 from utils.loss import ComputeLoss
 from utils.neuralmagic.quantization import update_model_bottlenecks
-from utils.neuralmagic.utils import ToggleableModelEMA, load_ema, nm_log_console
+from utils.neuralmagic.utils import ALMOST_ONE, ToggleableModelEMA, load_ema, nm_log_console
 from utils.torch_utils import ModelEMA, de_parallel
 
 __all__ = ["SparsificationManager", "maybe_create_sparsification_manager"]
@@ -77,7 +77,7 @@ class SparsificationManager(object):
         # thinning
         if self.checkpoint_manager:
             self.checkpoint_manager.apply_structure(
-                self.model, last_epoch if last_epoch >= 0 else float("inf")
+                self.model, last_epoch + ALMOST_ONE if last_epoch >= 0 else float("inf")
             )
 
         self.set_sparsification_info()
@@ -217,7 +217,9 @@ class SparsificationManager(object):
             # If resumed run, apply recipe structure up to last epoch run. Structure can
             # include QAT and layer thinning
             if resume:
-                self.train_manager.apply_structure(self.model, start_epoch - 1)
+                self.train_manager.apply_structure(
+                    self.model, start_epoch - 1 + ALMOST_ONE
+                )
 
             # Wrap the scaler for sparse training modifiers from recipe
             scaler = self.train_manager.modify(

--- a/utils/neuralmagic/utils.py
+++ b/utils/neuralmagic/utils.py
@@ -12,6 +12,7 @@ from utils.neuralmagic.quantization import update_model_bottlenecks
 from utils.torch_utils import ModelEMA
 
 __all__ = [
+    "ALMOST_ONE",
     "sparsezoo_download",
     "ToggleableModelEMA",
     "load_ema",
@@ -20,6 +21,7 @@ __all__ = [
 
 
 RANK = int(os.getenv("RANK", -1))
+ALMOST_ONE = 1 - 1e-9  # for incrementing epoch to be applied to recipe
 
 
 class ToggleableModelEMA(ModelEMA):
@@ -79,7 +81,7 @@ def load_sparsified_model(
     model = update_model_bottlenecks(model).to(device)
     checkpoint_manager = ScheduledModifierManager.from_yaml(ckpt["checkpoint_recipe"])
     checkpoint_manager.apply_structure(
-        model, ckpt["epoch"] if ckpt["epoch"] >= 0 else float("inf")
+        model, ckpt["epoch"] + ALMOST_ONE if ckpt["epoch"] >= 0 else float("inf")
     )
 
     # Load state dict


### PR DESCRIPTION
To account for cases where structural modifiers are at non-integer epochs

Example covered case:

- Your recipe has QAT start at epoch 0.001 (something the new yolov5 zoo recipes do)
- At the end of training you re-load your best model to do validation
- Your best model was one from epoch 0
- If you apply the recipe at epoch 0, you miss the QAT modifier and don't get quantized causing an error. If you apply the recipe at epoch 1, you may be catching a structural modifier this checkpoint never saw
