### PR TITLE
User control of data path

### DIFF
--- a/train.py
+++ b/train.py
@@ -66,8 +66,8 @@ WORLD_SIZE = int(os.getenv('WORLD_SIZE', 1))
 
 
 def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictionary
-    save_dir, epochs, batch_size, weights, single_cls, evolve, data, cfg, resume, noval, nosave, workers, freeze = \
-        Path(opt.save_dir), opt.epochs, opt.batch_size, opt.weights, opt.single_cls, opt.evolve, opt.data, opt.cfg, \
+    save_dir, epochs, batch_size, weights, single_cls, evolve, data, data_path, cfg, resume, noval, nosave, workers, freeze = \
+        Path(opt.save_dir), opt.epochs, opt.batch_size, opt.weights, opt.single_cls, opt.evolve, opt.data, opt.data_path, opt.cfg, \
         opt.resume, opt.noval, opt.nosave, opt.workers, opt.freeze
     callbacks.run('on_pretrain_routine_start')
 
@@ -108,7 +108,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
     cuda = device.type != 'cpu'
     init_seeds(opt.seed + 1 + RANK, deterministic=True)
     with torch_distributed_zero_first(LOCAL_RANK):
-        data_dict = data_dict or check_dataset(data)  # check if None
+        data_dict = data_dict or check_dataset(data, data_path)  # check if None
     train_path, val_path = data_dict['train'], data_dict['val']
     nc = 1 if single_cls else int(data_dict['nc'])  # number of classes
     names = {0: 'item'} if single_cls and len(data_dict['names']) != 1 else data_dict['names']  # class names
@@ -509,6 +509,7 @@ def parse_opt(known=False):
     parser.add_argument('--cfg', type=str, default='', help='model.yaml path')
     parser.add_argument('--teacher-weights', type=str, default='', help='distillation teacher initial weights path')
     parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='dataset.yaml path')
+    parser.add_argument('--data-path', type=str, default= '', help='path to dataset to overwrite the path in dataset.yaml')
     parser.add_argument('--hyp', type=str, default=ROOT / 'data/hyps/hyp.scratch-low.yaml', help='hyperparameters path')
     parser.add_argument('--epochs', type=int, default=300, help='total training epochs')
     parser.add_argument('--batch-size', type=int, default=16, help='total batch size for all GPUs, -1 for autobatch')

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -1032,7 +1032,7 @@ class HUBDatasetStats():
         stats.process_images()
     """
 
-    def __init__(self, path='coco128.yaml', autodownload=False):
+    def __init__(self, path='coco128.yaml', data_path = '', autodownload=False):
         # Initialize class
         zipped, data_dir, yaml_path = self._unzip(Path(path))
         try:
@@ -1043,7 +1043,7 @@ class HUBDatasetStats():
         except Exception as e:
             raise Exception("error/HUB/dataset_stats/yaml_load") from e
 
-        check_dataset(data, autodownload)  # download dataset if missing
+        check_dataset(data, data_path, autodownload)  # download dataset if missing
         self.hub_dir = Path(data['path'] + '-hub')
         self.im_dir = self.hub_dir / 'images'
         self.im_dir.mkdir(parents=True, exist_ok=True)  # makes /images

--- a/utils/general.py
+++ b/utils/general.py
@@ -466,7 +466,7 @@ def check_font(font=FONT, progress=False):
         torch.hub.download_url_to_file(url, str(file), progress=progress)
 
 
-def check_dataset(data, autodownload=True):
+def check_dataset(data, data_path = '', autodownload=True):
     # Download, check and/or unzip dataset if not found locally
 
     # Download (optional)
@@ -479,6 +479,8 @@ def check_dataset(data, autodownload=True):
     # Read yaml (optional)
     if isinstance(data, (str, Path)):
         data = yaml_load(data)  # dictionary
+        if data_path and 'path' in data:
+                data['path'] = data_path
 
     # Checks
     for k in 'train', 'val', 'names':

--- a/utils/loggers/comet/__init__.py
+++ b/utils/loggers/comet/__init__.py
@@ -94,7 +94,7 @@ class CometLogger:
         self.default_experiment_kwargs.update(experiment_kwargs)
         self.experiment = self._get_experiment(self.comet_mode, run_id)
 
-        self.data_dict = self.check_dataset(self.opt.data)
+        self.data_dict = self.check_dataset(self.opt.data, self.opt.data_path)
         self.class_names = self.data_dict["names"]
         self.num_classes = self.data_dict["nc"]
 
@@ -227,7 +227,7 @@ class CometLogger:
                 overwrite=True,
             )
 
-    def check_dataset(self, data_file):
+    def check_dataset(self, data_file, data_path):
         with open(data_file) as f:
             data_config = yaml.safe_load(f)
 
@@ -239,7 +239,7 @@ class CometLogger:
 
         self.log_asset(self.opt.data, metadata={"type": "data-config-file"})
 
-        return check_dataset(data_file)
+        return check_dataset(data_file, data_path)
 
     def log_predictions(self, image, labelsn, path, shape, predn):
         if self.logged_images_count >= self.max_images:

--- a/utils/neuralmagic/utils.py
+++ b/utils/neuralmagic/utils.py
@@ -115,6 +115,7 @@ def nm_log_console(message: str, logger: "Logger" = None, level: str = "info"):
 
 def export_sample_inputs_outputs(
     dataset: Union[str, Path],
+    data_path: str,
     model: torch.nn.Module,
     save_dir: Path,
     number_export_samples=100,
@@ -133,7 +134,7 @@ def export_sample_inputs_outputs(
     """
 
     # Create dataloader
-    data_dict = check_dataset(dataset)
+    data_dict = check_dataset(dataset, data_path)
     dataloader, _ = create_dataloader(
         path=data_dict["train"],
         imgsz=image_size,

--- a/val.py
+++ b/val.py
@@ -97,6 +97,7 @@ def process_batch(detections, labels, iouv):
 @smart_inference_mode()
 def run(
         data,
+        data_path='',
         weights=None,  # model.pt path(s)
         batch_size=32,  # batch size
         imgsz=640,  # inference size (pixels)
@@ -153,7 +154,7 @@ def run(
                 LOGGER.info(f'Forcing --batch-size 1 square inference (1,3,{imgsz},{imgsz}) for non-PyTorch models')
 
         # Data
-        data = check_dataset(data)  # check
+        data = check_dataset(data, data_path)  # check
 
     # Configure
     model.eval()
@@ -340,6 +341,7 @@ def run(
 def parse_opt():
     parser = argparse.ArgumentParser()
     parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='dataset.yaml path')
+    parser.add_argument('--data-path', type=str, default= '', help='path to dataset to overwrite the path in dataset.yaml')
     parser.add_argument('--weights', nargs='+', type=str, default=ROOT / 'yolov5s.pt', help='model path(s)')
     parser.add_argument('--batch-size', type=int, default=32, help='batch size')
     parser.add_argument('--imgsz', '--img', '--img-size', type=int, default=640, help='inference size (pixels)')


### PR DESCRIPTION
This PR adds an argument, `--data-path`, to all object detection scripts, which tells the script where to find the dataset. This prevents the need to re-download the dataset when working in a new directory

**Test Plan**
Manual testing