### PR TITLE
Add emulated step

### DIFF
--- a/train.py
+++ b/train.py
@@ -287,7 +287,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
             scheduler=scheduler,
             ema=ema,
             start_epoch=start_epoch,
-            steps_per_epoch=math.ceil(len(train_loader)/accumulate),
+            steps_per_epoch=len(train_loader),
             epochs=epochs,
             compute_loss=compute_loss,
             distillation_teacher=teacher_model,
@@ -384,6 +384,12 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
                 if ema:
                     ema.update(model)
                 last_opt_step = ni
+                
+            elif sparsification_manager:
+                # Call for SparseML integration since the number of steps per epoch can vary
+                # This keeps the number of steps per epoch equivalent to the number of batches per epoch
+                # Does not step the scaler or the optimizer
+                scaler.emulated_step()
 
             # Log
             if RANK in {-1, 0}:


### PR DESCRIPTION
In #152 `steps_per_epoch` was updated to scale with the gradient accumulation steps. This was a mistake, as the steps_per_epoch is generally not constant in yolov5. During training there is a warmup phase during which the gradient accumulation steps number scales up from 1 to its intended value. Instead, an emulated step should be called during each "non-update" step, which steps forward all SparseML modifiers but not the wrapped scaler/optimizer.

Test Plan
`python train.py --cfg yolov5s.yaml --sparsification-recipe yolov5_quant_recipe.yaml --gradient-accum-steps N`
where N was ran with each of [1, 2, 3] and each time was manually confirmed to follow the expected update pattern activate quantization at the correct step. The recipe used was:

```
# General variables
num_epochs: 6
init_lr: 1.e-6
final_lr: 2.e-7

# Quantization variables
observer_freeze_epoch: 1
bn_freeze_epoch: 1

training_modifiers:
  - !EpochRangeModifier
    start_epoch: 0
    end_epoch: eval(num_epochs)
    
  - !LearningRateFunctionModifier
    start_epoch: 0
    end_epoch: eval(num_epochs)
    lr_func: cosine
    init_lr: eval(init_lr)
    final_lr: eval(final_lr)
       
quantization_modifiers:
  - !QuantizationModifier
    start_epoch: 1.0
    submodules:
      - model
    custom_quantizable_module_types: ['SiLU']
    exclude_module_types: ['SiLU']
    quantize_conv_activations: False
    disable_quantization_observer_epoch: eval(observer_freeze_epoch)
    freeze_bn_stats_epoch: eval(bn_freeze_epoch)
```