### PR TITLE
More robust export pathway

### DIFF
--- a/utils/neuralmagic/utils.py
+++ b/utils/neuralmagic/utils.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Union
 import numpy
 import torch
 from sparseml.pytorch.optim import ScheduledModifierManager
-from sparseml.pytorch.utils import download_framework_model_by_recipe_type
+from sparseml.pytorch.utils import ModuleExporter, download_framework_model_by_recipe_type
 from sparsezoo import Model
 
 from models.yolo import Model as Yolov5Model
@@ -20,6 +20,7 @@ __all__ = [
     "ToggleableModelEMA",
     "load_ema",
     "load_sparsified_model",
+    "neuralmagic_onnx_export",
     "export_sample_inputs_outputs",
 ]
 
@@ -113,6 +114,78 @@ def nm_log_console(message: str, logger: "Logger" = None, level: str = "info"):
             logger.info(f"{colorstr('Neural Magic: ')}{message}")
 
 
+def neuralmagic_onnx_export(
+    model: torch.nn.Module,
+    sample_data: torch.Tensor,
+    weights_path: Path,
+    one_shot: Optional[str],
+    dynamic: Optional[Dict[str, int]],
+    output_names: List[str],
+) -> Path:
+    """
+    Augmented ONNX export to optimize and properly post-process sparsified models
+
+    :param model: model to export
+    :param sample_data: data to be used with export
+    :weights path: path from which the torch model was loaded. Used only for save
+        pathing and naming purposes
+    :one_shot: one_shot recipe, if one was applied. Used only for save pathing and
+        naming purposes
+    :param dynamic: dictionary of input or output names to list of dimensions
+        of those tensors that should be exported as dynamic
+    :output_names: names of output tensors
+
+    :return: path to saved ONNX model
+    """
+
+    # If the target model is a SparseZoo or YOLOv5 Hub model, save it to a
+    # DeepSparse_Deployment directory at the working directory root. Inside, create a
+    # subdirectory based on model/stub name
+    if str(weights_path).startswith("zoo:") or not len(weights_path.parents):
+        sub_dir = (
+            str(weights_path).split("zoo:")[1].replace("/", "_")
+            if str(weights_path).startswith("zoo:")
+            else weights_path
+        )
+
+        # If one-shot applying a recipe, update name to convey the starting stub/model
+        # and the one_shot recipe applied
+        if one_shot:
+            sub_dir = f"{sub_dir}_one_shot_{one_shot}"
+
+        save_dir = Path("DeepSparse_Deployment") / sub_dir
+        onnx_file_name = "model.onnx"
+
+    else:
+        save_dir = (
+            weights_path.parents[1] / "DeepSparse_Deployment"
+            if weights_path.parent.stem == "weights"
+            else weights_path.parent / "DeepSparse_Deployment"
+        )
+        onnx_file_name = weights_path.name
+
+    save_dir.mkdir(exist_ok=True)
+
+    nm_log_console("Exporting model to ONNX format")
+
+    # Use the SparseML custom onnx export flow for sparsified models
+    exporter = ModuleExporter(model, save_dir.absolute())
+    exporter.export_onnx(
+        sample_data,
+        name=onnx_file_name,
+        convert_qat=True,
+        input_names=["images"],
+        output_names=output_names,
+        dynamic_axes=dynamic or None,
+    )
+
+    saved_model_path = save_dir / onnx_file_name
+
+    nm_log_console(f"Exported ONNX model to {saved_model_path}")
+
+    return saved_model_path
+
+
 def export_sample_inputs_outputs(
     dataset: Union[str, Path],
     data_path: str,
@@ -132,6 +205,11 @@ def export_sample_inputs_outputs(
     :param image_size: image size
     :param onnx_path: Path to saved onnx model. Used to check if it uses uints8 inputs
     """
+
+    nm_log_console(
+        f"Exporting {number_export_samples} sample model inputs and outputs for "
+        "testing with the DeepSparse Engine"
+    )
 
     # Create dataloader
     data_dict = check_dataset(dataset, data_path)
@@ -200,6 +278,8 @@ def export_sample_inputs_outputs(
             f"and exported {exported_samples} samples",
             level="warning",
         )
+
+    nm_log_console(f"Complete export of {number_export_samples} to {save_dir}")
 
 
 def _graph_has_uint8_inputs(onnx_path: Union[str, Path]) -> bool:

--- a/utils/neuralmagic/utils.py
+++ b/utils/neuralmagic/utils.py
@@ -134,7 +134,6 @@ def neuralmagic_onnx_export(
     :param dynamic: dictionary of input or output names to list of dimensions
         of those tensors that should be exported as dynamic
     :output_names: names of output tensors
-
     :return: path to saved ONNX model
     """
 


### PR DESCRIPTION
The initial purpose of this PR was to update export pathing to be more robust and sensible. The logic got a bit hairy and it was much cleaner to create a new NM export utility, so now this PR does that as well.

**Save pathing updates**
- Models that exported directly from stubs will be saved to the directory `DeepSparse_Deployment`, relative to the working directory root. More specifically, to a sub directory which is named based on the stub and one-shot recipe, if used. Tested examples of command to save path:

Command
`python export.py --weights zoo:cv/detection/yolov5-n/pytorch/ultralytics/coco/base-none`
Model save path
 `DeepSparse_Deployment/cv_detection_yolov5-n_pytorch_ultralytics_coco_base-none/model.onnx`

Command
`python export.py --weights zoo:cv/detection/yolov5-n/pytorch/ultralytics/coco/base-none --one-shot zoo:cv/detection/yolov5-n/pytorch/ultralytics/coco/base_quant-none`
Model save path
`DeepSparse_Deployment/cv_detection_yolov5-n_pytorch_ultralytics_coco_base-none_one_shot_cv_detection_yolov5-n_pytorch_ultralytics_coco_base-none/model.onnx`

**Existing pathing behavior**
The nominal behavior covers models which are exported from a local directory. These are saved to the directory `DeepSparse_Deployment` either relative to the model or one directory up, if the parent directory is "weights". Examples:

Command
`python export.py --weights runs/train/exp90/weights/last.pt`
Model save path
`runs/train/exp90/DeepSparse_Deployment/last.onnx`

Command
`python export.py --weights my_models/yolov5s.pt`
Model save path
`my_models/DeepSparse_Deployment/yolov5s.onnx`

**Test Plan**
Commands above
