### PR TITLE
Legacy pickled models support

### DIFF
--- a/utils/neuralmagic/utils.py
+++ b/utils/neuralmagic/utils.py
@@ -35,7 +35,6 @@ ALMOST_ONE = 1 - 1e-9  # for incrementing epoch to be applied to recipe
 # pickled, pruned models.
 import models
 from models import common
-from utils.neuralmagic.quantization import _Add
 setattr(common, "_Add", _Add)  # Definition of the _Add module has moved
 
 # If using yolov5 as a repo and not a package, allow loading of models pickled w package

--- a/utils/neuralmagic/utils.py
+++ b/utils/neuralmagic/utils.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -11,7 +12,7 @@ from sparsezoo import Model
 from models.yolo import Model as Yolov5Model
 from utils.dataloaders import create_dataloader
 from utils.general import LOGGER, check_dataset, check_yaml, colorstr
-from utils.neuralmagic.quantization import update_model_bottlenecks
+from utils.neuralmagic.quantization import _Add, update_model_bottlenecks
 from utils.torch_utils import ModelEMA
 
 __all__ = [

--- a/utils/neuralmagic/utils.py
+++ b/utils/neuralmagic/utils.py
@@ -33,7 +33,9 @@ ALMOST_ONE = 1 - 1e-9  # for incrementing epoch to be applied to recipe
 # not quantized. We've now changed to never pickling a model touched by us. This
 # namespace hacking is meant to address backwards compatibility with previously
 # pickled, pruned models.
-sys.modules["yolov5.models.common._Add"] = _Add
+from models import common
+from utils.neuralmagic.quantization import _Add
+setattr(common, "_Add", _Add)
 
 
 class ToggleableModelEMA(ModelEMA):


### PR DESCRIPTION
This PR adds backwards compatibility for models that were pickled in a legacy version of our YOLOv5 integration. Three causes of errors are patched here:

- In the previous integration, we pickled any model that wasn't quantized. `load_sparsified_model` was updated to work with a pickled mode
- Our custom `_Add` has been moved, which causes unpickling issues. '_Add' has been programmatically added to common, where it is expected
- Our previous integration was always installed as a package, which means that all pickled classes are saved with the path `yolov5...`. With the new integration our tools can also be used in the ultralytics upstream repo. The `yolov5` and `yolov5.models` namespaces have been added to accomodate loading these legacy models on upstream as well.

**Test plan**
Local testing with legacy model on both installed package through SparseML and directly on fork
