### PR TITLE
Fix: suffix of saved onnx

### DIFF
--- a/utils/neuralmagic/utils.py
+++ b/utils/neuralmagic/utils.py
@@ -189,7 +189,7 @@ def neuralmagic_onnx_export(
             if weights_path.parent.stem == "weights"
             else weights_path.parent / "DeepSparse_Deployment"
         )
-        onnx_file_name = weights_path.name
+        onnx_file_name = weights_path.with_suffix(".onnx").name
 
     save_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
Bug Description: ONNX file incorrectly saved as `model.pt` instead of `model.onnx`, where 
Reproduction Steps:
1) Download the model
```bash
~ sparsezoo.download \
"zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned85_quant-none" \
--save-dir yolov5_model
```
2) Export the model
The checkpoint will be downloaded to `yolov5_model/training`
export command:
```bash
sparseml.yolov5.export_onnx --weights yolov5_model/training/model.pt
```
3) Notice the filenames, the ONNX file is saved as `model.pt`:
`yolov5_model/training/DeepSparse_Deployment/model.pt`

This PR fixes the bug, 
Test:

After running the command in Step 2 again , a `model.onnx` file was produced, verfied manually