### PR TITLE
Update NMBottleneck bn momentum & epsilon

### DIFF
--- a/utils/neuralmagic/quantization.py
+++ b/utils/neuralmagic/quantization.py
@@ -92,6 +92,10 @@ def update_model_bottlenecks(model: torch.nn.Module) -> torch.nn.Module:
             # Non-strict dict loading because class is initialized with identity batch
             # norm and yolov5 default checkpoints can exclude batch norm
             updated_module.load_state_dict(param.state_dict(), strict=False)
+            updated_module.cv1.bn.momentum = param.cv1.bn.momentum
+            updated_module.cv1.bn.eps = param.cv1.bn.eps
+            updated_module.cv2.bn.momentum = param.cv2.bn.momentum
+            updated_module.cv2.bn.eps = param.cv2.bn.eps
             new_bottlenecks.append(updated_module)
 
         elif isinstance(param, GhostBottleneck):
@@ -111,6 +115,10 @@ def update_model_bottlenecks(model: torch.nn.Module) -> torch.nn.Module:
             # Non-strict dict loading because class is initialized with identity batch
             # norm and yolov5 default checkpoints can exclude batch norm
             updated_module.load_state_dict(param.state_dict(), strict=False)
+            updated_module.cv1.bn.momentum = param.cv1.bn.momentum
+            updated_module.cv1.bn.eps = param.cv1.bn.eps
+            updated_module.cv2.bn.momentum = param.cv2.bn.momentum
+            updated_module.cv2.bn.eps = param.cv2.bn.eps
             new_bottlenecks.append(updated_module)
 
     # Replace found bottleneck modules


### PR DESCRIPTION
When replacing the Bottleneck layers with our own custom, quantizable layers, the momentum and epsilon for batch norm weren't getting copied over properly, resulting in small differences in the output. With this fix, the outputs are identical

**Test plan**
Manual self-distillation runs without training, verifying the distillation loss is 0