### PR TITLE
Self distillation support

### DIFF
--- a/train.py
+++ b/train.py
@@ -140,12 +140,15 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
             else None
         )
     amp = check_amp(model)  # check AMP
+    
+    # Knowledge distillation
     with torch_distributed_zero_first(LOCAL_RANK):
-        teacher_model = (
-            attempt_load(opt.teacher_weights, device=device) 
-            if (opt.teacher_weights and sparsification_manager and sparsification_manager.distillation_active) 
-            else None
-        )
+        if opt.teacher_weights == "self":
+            teacher_model = deepcopy(model.eval())
+        elif opt.teacher_weights and sparsification_manager and sparsification_manager.distillation_active:
+            teacher_model = attempt_load(opt.teacher_weights, device=device) 
+        else:
+            teacher_model = None
 
     # Freeze
     freeze = [f'model.{x}.' for x in (freeze if len(freeze) > 1 else range(freeze[0]))]  # layers to freeze
@@ -514,7 +517,7 @@ def parse_opt(known=False, skip_parse=False):
     parser = argparse.ArgumentParser()
     parser.add_argument('--weights', type=str, default=SAVE_ROOT / 'yolov5s.pt', help='initial weights path')
     parser.add_argument('--cfg', type=str, default='', help='model.yaml path')
-    parser.add_argument('--teacher-weights', type=str, default='', help='distillation teacher initial weights path')
+    parser.add_argument('--teacher-weights', type=str, default='', help='distillation teacher initial weights path, can be set to `self` for self distillation')
     parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='dataset.yaml path')
     parser.add_argument('--data-path', type=str, default= '', help='path to dataset to overwrite the path in dataset.yaml')
     parser.add_argument('--hyp', type=str, default=ROOT / 'data/hyps/hyp.scratch-low.yaml', help='hyperparameters path')

--- a/train.py
+++ b/train.py
@@ -143,10 +143,11 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
     
     # Knowledge distillation
     with torch_distributed_zero_first(LOCAL_RANK):
-        if opt.teacher_weights == "self":
-            teacher_model = deepcopy(model.eval())
-        elif opt.teacher_weights and sparsification_manager and sparsification_manager.distillation_active:
-            teacher_model = attempt_load(opt.teacher_weights, device=device) 
+        if opt.teacher_weights and sparsification_manager and sparsification_manager.distillation_active:
+            teacher_model = (
+                deepcopy(model.eval()) if opt.teacher_weights == "self" 
+                else attempt_load(opt.teacher_weights, device=device)
+            ) 
         else:
             teacher_model = None
 

--- a/utils/neuralmagic/quantization.py
+++ b/utils/neuralmagic/quantization.py
@@ -92,6 +92,10 @@ def update_model_bottlenecks(model: torch.nn.Module) -> torch.nn.Module:
             # Non-strict dict loading because class is initialized with identity batch
             # norm and yolov5 default checkpoints can exclude batch norm
             updated_module.load_state_dict(param.state_dict(), strict=False)
+            updated_module.cv1.bn.momentum = param.cv1.bn.momentum
+            updated_module.cv1.bn.eps = param.cv1.bn.eps
+            updated_module.cv2.bn.momentum = param.cv2.bn.momentum
+            updated_module.cv2.bn.eps = param.cv2.bn.eps
             new_bottlenecks.append(updated_module)
 
         elif isinstance(param, GhostBottleneck):
@@ -111,6 +115,10 @@ def update_model_bottlenecks(model: torch.nn.Module) -> torch.nn.Module:
             # Non-strict dict loading because class is initialized with identity batch
             # norm and yolov5 default checkpoints can exclude batch norm
             updated_module.load_state_dict(param.state_dict(), strict=False)
+            updated_module.cv1.bn.momentum = param.cv1.bn.momentum
+            updated_module.cv1.bn.eps = param.cv1.bn.eps
+            updated_module.cv2.bn.momentum = param.cv2.bn.momentum
+            updated_module.cv2.bn.eps = param.cv2.bn.eps
             new_bottlenecks.append(updated_module)
 
     # Replace found bottleneck modules


### PR DESCRIPTION
This PR adds support for distilling against a copy of the original student model

Test plan
```
python -m torch.distributed.run --no_python --nproc_per_node 2 \
sparseml.yolov5.train \
  --cfg yolov5s.yaml \
  --teacher-weights zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/base-none \
  --data coco.yaml \
  --batch-size 128 \
  --recipe zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned65-none \
  --hyp hyps/hyp.scratch-low.yaml \
  --weights zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/base-none \
  --patience 0 \
  --gradient-accum-steps 2
```
