### PR TITLE
Scale gradient clipping

### DIFF
--- a/train.py
+++ b/train.py
@@ -320,7 +320,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
 
         model.train()
 
-        clipping_constant = 10. * batch_size * accumulate * WORLD_SIZE / 64.
+        clipping_constant = 10. * batch_size * accumulate / 64.
 
         # Update image weights (optional, single-GPU only)
         if opt.image_weights:

--- a/train.py
+++ b/train.py
@@ -320,7 +320,8 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
 
         model.train()
 
-        clipping_constant = 10. * batch_size * accumulate / 64.
+        clipping_threshold = 10. * batch_size * accumulate / 64.
+        LOGGER.info(f'Adjusted gradient clipping threshold to {clipping_threshold}')
 
         # Update image weights (optional, single-GPU only)
         if opt.image_weights:
@@ -383,7 +384,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
             # Optimize - https://pytorch.org/docs/master/notes/amp_examples.html
             if ni - last_opt_step >= accumulate:
                 scaler.unscale_(optimizer)  # unscale gradients
-                torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=clipping_constant)  # clip gradients
+                torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=clipping_threshold)  # clip gradients
                 scaler.step(optimizer)  # optimizer.step
                 scaler.update()
                 optimizer.zero_grad()

--- a/train.py
+++ b/train.py
@@ -320,6 +320,8 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
 
         model.train()
 
+        clipping_constant = 10. * batch_size * accumulate * WORLD_SIZE / 64.
+
         # Update image weights (optional, single-GPU only)
         if opt.image_weights:
             cw = model.class_weights.cpu().numpy() * (1 - maps) ** 2 / nc  # class weights
@@ -381,7 +383,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
             # Optimize - https://pytorch.org/docs/master/notes/amp_examples.html
             if ni - last_opt_step >= accumulate:
                 scaler.unscale_(optimizer)  # unscale gradients
-                torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=10.0)  # clip gradients
+                torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=clipping_constant)  # clip gradients
                 scaler.step(optimizer)  # optimizer.step
                 scaler.update()
                 optimizer.zero_grad()


### PR DESCRIPTION
Scale gradient clipping threshold with effective batch size. This scaling is the same used for the loss (and thus gradients) and avoids gradient clipping being affected by batch size.

The threshold is set to be the same as the original code (10.0) if effective batch size is 64.