### PR TITLE
[Fix] Running `val.py` with `--deepsparse` flag

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -337,6 +337,7 @@ class DetectMultiBackend(nn.Module):
         pt, jit, onnx, xml, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs, paddle, triton = self._model_type(w)
         sparsezoo = str(w).startswith("zoo:")
         pt = pt or sparsezoo
+        pt = pt and not deepsparse # if deepsparse, use sparsezoo with the deepsparse engine, not pytorch
         fp16 &= (pt and not sparsezoo) or jit or onnx or engine  # FP16
         nhwc = coreml or saved_model or pb or tflite or edgetpu  # BHWC formats (vs torch BCWH)
         stride = 32  # default stride
@@ -344,7 +345,7 @@ class DetectMultiBackend(nn.Module):
         if not (pt or triton):
             w = attempt_download(w)  # download if not local
 
-        if pt or sparsezoo:  # PyTorch
+        if pt or sparsezoo and not deepsparse:  # PyTorch
             model = attempt_load(weights if isinstance(weights, list) else w, device=device, inplace=True, fuse=fuse)
             stride = max(int(model.stride.max()), 32)  # model stride
             names = model.module.names if hasattr(model, 'module') else model.names  # get class names

--- a/models/common.py
+++ b/models/common.py
@@ -337,8 +337,8 @@ class DetectMultiBackend(nn.Module):
         pt, jit, onnx, xml, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs, paddle, triton = self._model_type(w)
         sparsezoo = str(w).startswith("zoo:")
         pt = pt or sparsezoo
-        pt = pt and not deepsparse # if deepsparse, use sparsezoo with the deepsparse engine, not pytorch
         fp16 &= (pt and not sparsezoo) or jit or onnx or engine  # FP16
+        pt = pt and not deepsparse # if deepsparse, use sparsezoo with the deepsparse engine, not pytorch
         nhwc = coreml or saved_model or pb or tflite or edgetpu  # BHWC formats (vs torch BCWH)
         stride = 32  # default stride
         cuda = torch.cuda.is_available() and device.type != 'cpu'  # use CUDA

--- a/utils/neuralmagic/quantization.py
+++ b/utils/neuralmagic/quantization.py
@@ -1,13 +1,20 @@
 import torch
-
-from models.common import Bottleneck, GhostBottleneck
+import onnx
+from models.common import Bottleneck, GhostBottleneck, DetectMultiBackend
 
 try:
     from torch.nn.quantized import FloatFunctional
 except Exception:
     FloatFunctional = None
 
-__all__ = ["NMGhostBottleneck", "NMBottleneck", "update_model_bottlenecks"]
+__all__ = ["NMGhostBottleneck", "NMBottleneck", "update_model_bottlenecks", "is_quantized"]
+
+def is_quantized(model: DetectMultiBackend) -> bool:
+    """
+    Check if DetectMultiBackend model is quantized
+    """
+    onnx_model = onnx.load_model(model.ds_engine.model_path)
+    return onnx_model.graph.input[0].type.tensor_type.elem_type == onnx.TensorProto.UINT8
 
 
 class _Add(torch.nn.Module):

--- a/val.py
+++ b/val.py
@@ -37,6 +37,7 @@ SAVE_ROOT = Path.cwd()
 ROOT = Path(os.path.relpath(ROOT, SAVE_ROOT))  # relative
 
 from models.common import DetectMultiBackend
+from utils.neuralmagic.quantization import is_quantized
 from utils.callbacks import Callbacks
 from utils.dataloaders import create_dataloader
 from utils.general import (LOGGER, Profile, check_dataset, check_img_size, check_requirements, check_yaml,
@@ -203,9 +204,12 @@ def run(
             if cuda:
                 im = im.to(device, non_blocking=True)
                 targets = targets.to(device)
-            im = im.half() if half else im.float()  # uint8 to fp16/32
-            im /= 255  # 0 - 255 to 0.0 - 1.0
-            nb, _, height, width = im.shape  # batch size, channels, height, width
+            if deepsparse and is_quantized(model):
+                nb, _, height, width = im.shape  # batch size, channels, height, width
+            else:
+                im = im.half() if half else im.float()  # uint8 to fp16/32
+                im /= 255  # 0 - 255 to 0.0 - 1.0
+                nb, _, height, width = im.shape  # batch size, channels, height, width
 
         # Inference
         with dt[1]:
@@ -343,7 +347,7 @@ def parse_opt(skip_parse=False):
     parser = argparse.ArgumentParser()
     parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='dataset.yaml path')
     parser.add_argument('--data-path', type=str, default= '', help='path to dataset to overwrite the path in dataset.yaml')
-    parser.add_argument('--weights', nargs='+', type=str, default=SAVE_ROOT / 'yolov5s.pt', help='model path(s)')
+    parser.add_argument('--weights', nargs='+', type=str, default='zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned85_quant-none', help='model path(s)')
     parser.add_argument('--batch-size', type=int, default=32, help='batch size')
     parser.add_argument('--imgsz', '--img', '--img-size', type=int, default=640, help='inference size (pixels)')
     parser.add_argument('--conf-thres', type=float, default=0.001, help='confidence threshold')
@@ -418,4 +422,5 @@ def val_run(**kwargs):
 
 if __name__ == "__main__":
     opt = parse_opt()
+    opt.deepsparse=True
     main(opt)

--- a/val.py
+++ b/val.py
@@ -204,12 +204,13 @@ def run(
             if cuda:
                 im = im.to(device, non_blocking=True)
                 targets = targets.to(device)
+                
             if deepsparse and is_quantized(model):
-                nb, _, height, width = im.shape  # batch size, channels, height, width
+                pass # no additional preprocessing needed
             else:
                 im = im.half() if half else im.float()  # uint8 to fp16/32
                 im /= 255  # 0 - 255 to 0.0 - 1.0
-                nb, _, height, width = im.shape  # batch size, channels, height, width
+            nb, _, height, width = im.shape  # batch size, channels, height, width
 
         # Inference
         with dt[1]:


### PR DESCRIPTION
Fix to the bug: https://app.asana.com/0/1201735099598270/1203940813196775/f

Note: Is the difference in mAP for some models depending on the inference engine within the correct boundaries? I am a bit doubtful here.

# Manual Testing Journal

The `pruned and quantized` model tested: zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned85_quant-none
The `pruned` model tested: zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned35-none-vnni
Any other models used were the default yolov5n models (.pt or .onnx)

## Case 1: Evaluate ONNX in ORT
```bash
mAP50 -> 0.711
Results saved to /home/ubuntu/damian/yolov5/yolov5_runs/val/exp68
```

## Case 2: Evaluate ONNX in DeepSparse
```bash
mAP50 -> 0.711
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.3.2 COMMUNITY | (7d31c4bf) (release) (optimized) (system=avx2, binary=avx2)
...
Results saved to /home/ubuntu/damian/yolov5/yolov5_runs/val/exp69
```

## Case 3: Evaluate pruned and quantized SparseZoo model

```bash
mAP50 -> 0.605
Results saved to /home/ubuntu/damian/yolov5/yolov5_runs/val/exp70
```

## Case 4: Evaluate pruned and quantized SparseZoo model in DeepSparse

```bash
mAP50 -> 0.615
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.3.2 COMMUNITY | (7d31c4bf) (release) (optimized) (system=avx2, binary=avx2)
...
Results saved to /home/ubuntu/damian/yolov5/yolov5_runs/val/exp71
```

## Case 5: Evaluated pruned SparseZoo model

```bash
mAP50 -> 0.693
Results saved to /home/ubuntu/damian/yolov5/yolov5_runs/val/exp72
```

## Case 6: Evaluated pruned SparseZoo model in DeepSparse

```bash
mAP50 -> 0.687
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.3.2 COMMUNITY | (7d31c4bf) (release) (optimized) (system=avx2, binary=avx2)
...
Results saved to /home/ubuntu/damian/yolov5/yolov5_runs/val/exp73
```

## Case 7: Eval .pt model with --deepsparse flag

```bash
RuntimeError: NM: error: /home/ubuntu/build/nyann/external/onnx-runtime/onnxruntime/core/session/inference_session.cc:445 onnxruntime::InferenceSession::InferenceSession(const onnxruntime::SessionOptions&, const onnxruntime::Environment&, const string&) status.IsOK() was false. Given model could not be parsed while creating inference session. Error message: Protobuf parsing failed.
```
## Case 8: Eval .pt model

```bash
mAP50 -> 0.714
Results saved to /home/ubuntu/damian/yolov5/yolov5_runs/val/exp68
```
