### PR TITLE
[Fix] Generation of input/output samples for non-sparsified models 

### DIFF
--- a/val.py
+++ b/val.py
@@ -348,7 +348,7 @@ def parse_opt(skip_parse=False):
     parser = argparse.ArgumentParser()
     parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='dataset.yaml path')
     parser.add_argument('--data-path', type=str, default= '', help='path to dataset to overwrite the path in dataset.yaml')
-    parser.add_argument('--weights', nargs='+', type=str, default='zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned85_quant-none', help='model path(s)')
+    parser.add_argument('--weights', nargs='+', type=str, default=SAVE_ROOT / 'yolov5s.pt', help='model path(s)')
     parser.add_argument('--batch-size', type=int, default=32, help='batch size')
     parser.add_argument('--imgsz', '--img', '--img-size', type=int, default=640, help='inference size (pixels)')
     parser.add_argument('--conf-thres', type=float, default=0.001, help='confidence threshold')
@@ -423,5 +423,4 @@ def val_run(**kwargs):
 
 if __name__ == "__main__":
     opt = parse_opt()
-    opt.deepsparse=True
     main(opt)


### PR DESCRIPTION
Fix for https://app.asana.com/0/1203126676641557/1203962634484913

@anmarques I assume that the sample generation failed for you, because you were exporting a non-sparsified model. This is because the sample generation pathway only activates if `sparsified==True`. 
This condition is met if `sparsified = getattr(model, "sparsified", False) or one_shot`.

I have pulled the sample generation out of the `if-` statement, so now samples are generated regardless of the boolean value of `sparsified`

Testing:
```bash
sparseml.yolov5.export_onnx  --dynamic --export-samples 20
```
```bash
export: data=data/coco128.yaml, data_path=, weights=/home/ubuntu/damian/yolov5/yolov5s.pt, imgsz=[640, 640], batch_size=1, device=cpu, half=False, inplace=False, keras=False, optimize=False, int8=False, dynamic=False, simplify=False, opset=12, verbose=False, workspace=4, nms=False, agnostic_nms=False, topk_per_class=100, topk_all=100, iou_thres=0.45, conf_thres=0.25, export_samples=0, include=['onnx'], one_shot=None
YOLOv5 🚀 v1.4-32-gbe9c0f9 Python-3.8.10 torch-1.12.1+cu116 CPU

Fusing layers... 
YOLOv5s summary: 213 layers, 7225885 parameters, 0 gradients

PyTorch: starting from /home/ubuntu/damian/yolov5/yolov5s.pt with output shape (1, 25200, 85) (14.1 MB)

ONNX: starting export with onnx 1.12.0...
Neural Magic: Exporting 20 sample model inputs and outputs for testing with the DeepSparse Engine
train: Scanning '/home/ubuntu/damian/datasets/coco128/labels/train2017.cache' images and labels... 126 found, 2 missing, 0 empty, 0 corrupt: 100%|██████████| 128/128 [00:00<?, ?it/s]
Neural Magic: Complete export of 20 to /home/ubuntu/damian/yolov5
ONNX: export success ✅ 3.7s, saved as /home/ubuntu/damian/yolov5/yolov5s.onnx (27.6 MB)

Export complete (4.1s)
Results saved to /home/ubuntu/damian/yolov5
```