### PR TITLE
[Fix] Two confusing "val:" prints when sparseml.yolov5.validation has args specified

### DIFF
--- a/val.py
+++ b/val.py
@@ -384,7 +384,7 @@ def parse_opt(skip_parse=False):
 
 def main(opt):
     check_requirements(exclude=('tensorboard', 'thop'))
-
+    print_args(vars(opt))
     if opt.task in ('train', 'val', 'test'):  # run normally
         if opt.conf_thres > 0.001:  # https://github.com/ultralytics/yolov5/issues/1466
             LOGGER.info(f'WARNING ⚠️ confidence threshold {opt.conf_thres} > 0.001 produces invalid results')

--- a/val.py
+++ b/val.py
@@ -378,12 +378,12 @@ def parse_opt(skip_parse=False):
     opt.data = check_yaml(opt.data)  # check YAML
     opt.save_json |= opt.data.endswith('coco.yaml')
     opt.save_txt |= opt.save_hybrid
-    print_args(vars(opt))  
     return opt
 
 
 def main(opt):
     check_requirements(exclude=('tensorboard', 'thop'))
+
     print_args(vars(opt))
     if opt.task in ('train', 'val', 'test'):  # run normally
         if opt.conf_thres > 0.001:  # https://github.com/ultralytics/yolov5/issues/1466


### PR DESCRIPTION
Fix for: https://app.asana.com/0/1201735099598270/1203967510531024

## Feature description
The function responsible for stdout:`val: ...` is `print_args`.  This PR moves this function from `parse_opt` method to `main(...)`

## Explanation:
Before, the printing of args happened in the `parse_opt` function. Let's examine what was happening when we called:
`sparseml.yolov5.validation` with kwargs or without kwargs.  Let's bring up the responsible code from `sparseml`:

```python
def val(**kwargs):
    """
    Hook to call into val.py in YOLOv5 fork
    """
    if kwargs:
        val_run(**kwargs)
    else:
        opt = parse_val_args()
        val_run(**vars(opt))
```
### Kwargs specified:
Command `sparseml.yolov5.validation --something 10`. Not the happy path, but it jumps directly to the `val_run` function, so in theory, it should run `print_args` just once (inside `val_run(...)`)

### No kwargs specified:
Command: `sparseml.yolov5.validation --deepsparse`. In this vanilla scenario we specify arguments but no kwargs. As result, we "visit" the `print_args` function twice:  when running `opt = parse_val_args()` and for the second time inside `val_run(...)`. Naturally, the contents of the print are different. The first print displays the default configs, and the second one displays the actual configs (after they have been updated). Hence the observation described in the bug report:
"Most striking is that when the --deepsparse arg is passed to the command, the first "val:" shows deepsparse=True and deepsparse=False for the second, but when --deepsparse arg is not passed to the command deepsparse=False for both "val:".

Moved the printing to `main(...)` function, since this is the target function that gets invoked once and contains the actual logic.

