### PR TITLE
[Cherry pick][Fix] Two confusing "val:" prints when sparseml.yolov5.validation has args specified

### DIFF
--- a/val.py
+++ b/val.py
@@ -384,7 +384,7 @@ def parse_opt(skip_parse=False):
 
 def main(opt):
     check_requirements(exclude=('tensorboard', 'thop'))
-
+    print_args(vars(opt))
     if opt.task in ('train', 'val', 'test'):  # run normally
         if opt.conf_thres > 0.001:  # https://github.com/ultralytics/yolov5/issues/1466
             LOGGER.info(f'WARNING ⚠️ confidence threshold {opt.conf_thres} > 0.001 produces invalid results')

--- a/val.py
+++ b/val.py
@@ -378,12 +378,12 @@ def parse_opt(skip_parse=False):
     opt.data = check_yaml(opt.data)  # check YAML
     opt.save_json |= opt.data.endswith('coco.yaml')
     opt.save_txt |= opt.save_hybrid
-    print_args(vars(opt))  
     return opt
 
 
 def main(opt):
     check_requirements(exclude=('tensorboard', 'thop'))
+
     print_args(vars(opt))
     if opt.task in ('train', 'val', 'test'):  # run normally
         if opt.conf_thres > 0.001:  # https://github.com/ultralytics/yolov5/issues/1466


### PR DESCRIPTION
Cherry pick for: https://github.com/neuralmagic/yolov5/pull/177