### PR TITLE
Updated QAT batch size scaling

### DIFF
--- a/train.py
+++ b/train.py
@@ -311,12 +311,15 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
 
             if not sparsification_manager.quantized_checkpoint:
                 # Rescale batch size for QAT
-                batch_size, accumulate = sparsification_manager.rescale_gradient_accumulation(
+                new_batch_size, new_accumulate = sparsification_manager.rescale_gradient_accumulation(
                     batch_size=batch_size, 
                     accumulate=accumulate, 
                     image_size=imgsz
                 )
-                train_loader, dataset, val_loader = _create_dataloaders()
+                if new_batch_size != batch_size:
+                    batch_size = new_batch_size
+                    accumulate = new_accumulate
+                    train_loader, dataset, val_loader = _create_dataloaders()
 
         model.train()
 

--- a/utils/neuralmagic/sparsification_manager.py
+++ b/utils/neuralmagic/sparsification_manager.py
@@ -416,7 +416,7 @@ class SparsificationManager(object):
                 "accumulation steps for QAT"
             )
 
-            if new_accumulate * new_batch_size != batch_size * accumulate:
+            if new_accumulate * new_batch_size != effective_batch_size:
                 self.log_console(
                     "New effective batch size doesn't match previous effective batch size. "
                     f"Previous effective batch size: {batch_size * accumulate}. "

--- a/utils/neuralmagic/sparsification_manager.py
+++ b/utils/neuralmagic/sparsification_manager.py
@@ -397,7 +397,7 @@ class SparsificationManager(object):
 
         # Calculate maximum batch size that will fit in memory
         batch_size_max = (
-            check_train_batch_size(self.model, image_size, False) / QAT_BATCH_SCALE
+            check_train_batch_size(self.model, image_size, False) // QAT_BATCH_SCALE
         )
 
         if batch_size > batch_size_max:

--- a/utils/neuralmagic/sparsification_manager.py
+++ b/utils/neuralmagic/sparsification_manager.py
@@ -11,6 +11,7 @@ from utils.loggers import Loggers
 from utils.loss import ComputeLoss
 from utils.neuralmagic.quantization import update_model_bottlenecks
 from utils.neuralmagic.utils import ALMOST_ONE, QAT_BATCH_SCALE, ToggleableModelEMA, load_ema, nm_log_console
+from utils.torch_utils import ModelEMA
 
 __all__ = [
     "SparsificationManager",

--- a/utils/neuralmagic/sparsification_manager.py
+++ b/utils/neuralmagic/sparsification_manager.py
@@ -419,7 +419,7 @@ class SparsificationManager(object):
             if new_accumulate * new_batch_size != effective_batch_size:
                 self.log_console(
                     "New effective batch size doesn't match previous effective batch size. "
-                    f"Previous effective batch size: {batch_size * accumulate}. "
+                    f"Previous effective batch size: {effective_batch_size}. "
                     f"New effective batch size: {new_batch_size * new_accumulate}",
                     level="warning",
                 )

--- a/utils/neuralmagic/utils.py
+++ b/utils/neuralmagic/utils.py
@@ -17,6 +17,7 @@ from utils.torch_utils import ModelEMA
 
 __all__ = [
     "ALMOST_ONE",
+    "QAT_BATCH_SCALE",
     "sparsezoo_download",
     "ToggleableModelEMA",
     "load_ema",
@@ -28,6 +29,7 @@ __all__ = [
 SAVE_ROOT = Path.cwd()
 RANK = int(os.getenv("RANK", -1))
 ALMOST_ONE = 1 - 1e-9  # for incrementing epoch to be applied to recipe
+QAT_BATCH_SCALE = 4  # batch size scaling to set upper limit when starting QAT
 
 # In previous integrations of NM YOLOv5, we were pickling models as long as they are
 # not quantized. We've now changed to never pickling a model touched by us. This


### PR DESCRIPTION
This PR updates the logic for scaling down batch size when QAT is turned on. The new logic flow is:

1. Run auto-batch on full FP32 model and 
2. Divide the resulting batch size by a scaling constant (4) and set that as the maximum batch size
3. If the current batch size is <= maximum batch size, do nothing
4. Otherwise, set new batch size to the maximum batch size
5. Rescale the accumulation steps and create new dataloaders (already a part of the current implementation)

Test plan
Local testing with quantization recipe