### PR TITLE
Handle missing `hyps` in the exported model

### DIFF
--- a/utils/neuralmagic/utils.py
+++ b/utils/neuralmagic/utils.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import yaml
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -222,6 +223,7 @@ def export_sample_inputs_outputs(
     number_export_samples=100,
     image_size: int = 640,
     onnx_path: Union[str, Path, None] = None,
+    default_hyp:str = 'data/hyps/hyp.scratch-low.yaml',
 ):
     """
     Export sample model input and output for testing with the DeepSparse Engine
@@ -238,6 +240,14 @@ def export_sample_inputs_outputs(
         f"Exporting {number_export_samples} sample model inputs and outputs for "
         "testing with the DeepSparse Engine"
     )
+
+    if model.hyp is None:
+        FILE = Path(__file__).resolve()
+        ROOT = FILE.parents[2]  # YOLOv5 root directory
+        HYPS_DIR = ROOT/default_hyp
+        nm_log_console(f"The model hyper-parameters are not set, using defaults from {HYPS_DIR}.")
+        with open(HYPS_DIR, errors='ignore') as f:
+            model.hyp = yaml.safe_load(f)
 
     # Create dataloader
     data_dict = check_dataset(dataset, data_path)


### PR DESCRIPTION
## Feature Description

Before: `--weights` parameter, which specified a model without the baked-in `hyps` could not be used together with `--export-samples` parameter. The missing `hyps` were silently breaking the dataset for generating samples.

Now: when `hyps` are missing, the default hyps (same defaults as in training) are evoked.

## Testing 

```bash
sparseml.yolov5.export_onnx --dynamic --weights model.pt --export-samples 20
```
Returns:

```bash
export: data=data/coco128.yaml, data_path=, weights=/home/ubuntu/damian/yolov5/yolov5s.pt, imgsz=[640, 640], batch_size=1, device=cpu, half=False, inplace=False, keras=False, optimize=False, int8=False, dynamic=False, simplify=False, opset=12, verbose=False, workspace=4, nms=False, agnostic_nms=False, topk_per_class=100, topk_all=100, iou_thres=0.45, conf_thres=0.25, export_samples=0, include=['onnx'], one_shot=None
YOLOv5 🚀 v1.5-3-g0caf9a4 Python-3.8.10 torch-1.12.1+cu116 CPU

Neural Magic: Loading sparsified model

                 from  n    params  module                                  arguments                     
  0                -1  1      3520  models.common.Conv                      [3, 32, 6, 2, 2]              
  1                -1  1     18560  models.common.Conv                      [32, 64, 3, 2]                
  2                -1  1     18816  models.common.C3                        [64, 64, 1]                   
  3                -1  1     73984  models.common.Conv                      [64, 128, 3, 2]               
  4                -1  2    115712  models.common.C3                        [128, 128, 2]                 
  5                -1  1    295424  models.common.Conv                      [128, 256, 3, 2]              
  6                -1  3    625152  models.common.C3                        [256, 256, 3]                 
  7                -1  1   1180672  models.common.Conv                      [256, 512, 3, 2]              
  8                -1  1   1182720  models.common.C3                        [512, 512, 1]                 
  9                -1  1    656896  models.common.SPPF                      [512, 512, 5]                 
 10                -1  1    131584  models.common.Conv                      [512, 256, 1, 1]              
 11                -1  1         0  torch.nn.modules.upsampling.Upsample    [None, 2, 'nearest']          
 12           [-1, 6]  1         0  models.common.Concat                    [1]                           
 13                -1  1    361984  models.common.C3                        [512, 256, 1, False]          
 14                -1  1     33024  models.common.Conv                      [256, 128, 1, 1]              
 15                -1  1         0  torch.nn.modules.upsampling.Upsample    [None, 2, 'nearest']          
 16           [-1, 4]  1         0  models.common.Concat                    [1]                           
 17                -1  1     90880  models.common.C3                        [256, 128, 1, False]          
 18                -1  1    147712  models.common.Conv                      [128, 128, 3, 2]              
 19          [-1, 14]  1         0  models.common.Concat                    [1]                           
 20                -1  1    296448  models.common.C3                        [256, 256, 1, False]          
 21                -1  1    590336  models.common.Conv                      [256, 256, 3, 2]              
 22          [-1, 10]  1         0  models.common.Concat                    [1]                           
 23                -1  1   1182720  models.common.C3                        [512, 512, 1, False]          
 24      [17, 20, 23]  1    229245  models.yolo.Detect                      [80, [[10, 13, 16, 30, 33, 23], [30, 61, 62, 45, 59, 119], [116, 90, 156, 198, 373, 326]], [128, 256, 512]]
Model summary: 214 layers, 7235389 parameters, 7235389 gradients, 16.6 GFLOPs


PyTorch: starting from model.pt with output shape (1, 25200, 85) (14.0 MB)

ONNX: starting export with onnx 1.12.0...
Neural Magic: Exporting model to ONNX format
/home/ubuntu/damian/yolov5/venv/lib/python3.8/site-packages/torch/onnx/utils.py:439: UserWarning: It is recommended that constant folding be turned off ('do_constant_folding=False') when exporting the model in training-amenable mode, i.e. with 'training=TrainingMode.TRAIN' or 'training=TrainingMode.PRESERVE' (when model is in training mode). Otherwise, some learnable model parameters may not translate correctly in the exported ONNX model because constant folding mutates model parameters. Please consider turning off constant folding or setting the training=TrainingMode.EVAL.
  warnings.warn(
WARNING: The shape inference of prim::Constant type is missing, so it may result in wrong shape inference for the exported graph. Please consider adding it in symbolic function.
WARNING: The shape inference of prim::Constant type is missing, so it may result in wrong shape inference for the exported graph. Please consider adding it in symbolic function.
WARNING: The shape inference of prim::Constant type is missing, so it may result in wrong shape inference for the exported graph. Please consider adding it in symbolic function.
WARNING: The shape inference of prim::Constant type is missing, so it may result in wrong shape inference for the exported graph. Please consider adding it in symbolic function.
WARNING: The shape inference of prim::Constant type is missing, so it may result in wrong shape inference for the exported graph. Please consider adding it in symbolic function.
WARNING: The shape inference of prim::Constant type is missing, so it may result in wrong shape inference for the exported graph. Please consider adding it in symbolic function.
Neural Magic: Exported ONNX model to DeepSparse_Deployment/model.onnx
Neural Magic: Exporting 20 sample model inputs and outputs for testing with the DeepSparse Engine
Neural Magic: The model hyper-parameters are not set, using defaults from /home/ubuntu/damian/yolov5/data/hyps/hyp.scratch-low.yaml.
train: Scanning '/home/ubuntu/damian/datasets/coco128/labels/train2017.cache' images and labels... 126 found, 2 missing, 0 empty, 0 corrupt: 100%|██████████| 128/128 [00:00<?, ?it/s]
Neural Magic: Complete export of 20 to DeepSparse_Deployment
ONNX: export success ✅ 5.5s, saved as DeepSparse_Deployment/model.onnx (27.7 MB)

Export complete (6.0s)
Results saved to /home/ubuntu/damian/yolov5
Detect:          python detect.py --weights DeepSparse_Deployment/model.onnx 
Validate:        python val.py --weights DeepSparse_Deployment/model.onnx 
PyTorch Hub:     model = torch.hub.load('ultralytics/yolov5', 'custom', 'DeepSparse_Deployment/model.onnx')  
Visualize:       https://netron.app
```