### PR TITLE
Load ema from checkpoint as torch.nn.Module

### DIFF
--- a/utils/neuralmagic/sparsification_manager.py
+++ b/utils/neuralmagic/sparsification_manager.py
@@ -601,7 +601,7 @@ def maybe_create_sparsification_manager(
 
         # reconstruct ToggleableModelEMA from state dictionary
         if ckpt["ema"]:
-            ckpt["ema"] = load_ema(ckpt["ema"], model)
+            ckpt["ema"] = load_ema(ckpt["ema"], model).ema
 
         return sparsification_manager
 


### PR DESCRIPTION
The ema saved in the checkpoint is only ever used to re-load the state of the ema for a resume run, in which case it's expected that the checkpoint is of type `torch.nn.Module`. This PR fixes the loading issue that comes up with a simple change to the NM ema loading logic