### PR TITLE
[Bug-fix] Support for exporting intermediate checkpoints

### DIFF
--- a/models/experimental.py
+++ b/models/experimental.py
@@ -79,7 +79,7 @@ def attempt_load(weights, device=None, inplace=True, fuse=True):
     for w in weights if isinstance(weights, list) else [weights]:
         ckpt = torch.load(attempt_download(w) if not str(w).startswith("zoo:") 
                 else sparsezoo_download(w), map_location='cpu')  # load
-        sparsified = bool(ckpt.get("checkpoint_recipe"))
+        sparsified = bool(ckpt.get("checkpoint_recipe") or ckpt.get("intermediate_recipe"))
         
         ckpt = (
             (ckpt.get('ema') or ckpt['model']).to(device).float() 

--- a/utils/neuralmagic/sparsification_manager.py
+++ b/utils/neuralmagic/sparsification_manager.py
@@ -394,11 +394,11 @@ class SparsificationManager(object):
         effective_batch_size = batch_size * accumulate
         batch_size = max(batch_size // QAT_BATCH_SCALE, 1)
         accumulate = effective_batch_size // batch_size
-        
+
         self.log_console(
-                f"Batch size rescaled to {batch_size} with {accumulate} gradient "
-                "accumulation steps for QAT"
-            )
+            f"Batch size rescaled to {batch_size} with {accumulate} gradient "
+            "accumulation steps for QAT"
+        )
 
         if accumulate * batch_size != effective_batch_size:
             self.log_console(
@@ -461,7 +461,7 @@ class SparsificationManager(object):
         """
         # checkpoint recipe saved with final models, for state re-construction upon
         # loading for validation or additional stage of sparsification
-        checkpoint_recipe = self.get_final_checkpoint_recipe() if final_epoch else None
+        composed_recipe = self.get_final_checkpoint_recipe()
 
         # Pickling is not supported for quantized models for a subset of the supported
         # torch versions, thus all sparse models are saved via their state dict
@@ -470,7 +470,9 @@ class SparsificationManager(object):
             "yaml": ckpt["model"].yaml,
             "ema": ckpt["ema"].state_dict() if ema_enabled else None,
             "updates": ckpt["updates"] if ema_enabled else None,
-            "checkpoint_recipe": str(checkpoint_recipe) if checkpoint_recipe else None,
+            "checkpoint_recipe": str(composed_recipe) if final_epoch else None,
+            # Saved to support export of intermediate checkpoints
+            "intermediate_recipe": str(composed_recipe) if not final_epoch else None,
             "epoch": -1 if final_epoch else ckpt["epoch"],
             "nc": number_classes,
         }

--- a/utils/neuralmagic/utils.py
+++ b/utils/neuralmagic/utils.py
@@ -108,9 +108,12 @@ def load_sparsified_model(
         checkpoint_manager = ScheduledModifierManager.from_yaml(
             ckpt["checkpoint_recipe"] or ckpt["intermediate_recipe"]
         )
-        checkpoint_manager.apply_structure(
-            model, ckpt["epoch"] + ALMOST_ONE if ckpt["epoch"] >= 0 else float("inf")
+        epoch = (
+            checkpoint_manager.get_last_start_epoch() + ckpt["epoch"] + ALMOST_ONE
+            if ckpt["epoch"] >= 0
+            else float("inf")
         )
+        checkpoint_manager.apply_structure(model, epoch)
 
         # Load state dict
         model.load_state_dict(ckpt["ema"] or ckpt["model"], strict=True)

--- a/utils/neuralmagic/utils.py
+++ b/utils/neuralmagic/utils.py
@@ -106,7 +106,7 @@ def load_sparsified_model(
         model = Yolov5Model(ckpt.get("yaml"))
         model = update_model_bottlenecks(model).to(device)
         checkpoint_manager = ScheduledModifierManager.from_yaml(
-            ckpt["checkpoint_recipe"]
+            ckpt["checkpoint_recipe"] or ckpt["intermediate_recipe"]
         )
         checkpoint_manager.apply_structure(
             model, ckpt["epoch"] + ALMOST_ONE if ckpt["epoch"] >= 0 else float("inf")


### PR DESCRIPTION
Currently exporting intermediate checkpoints is not supported. This is unintended behavior and this PR adds the capability by saving an `"intermediate_recipe"` which can be used to load intermediate checkpoints to the correct state. It is added as a separate checkpoint entry to prevent breaking` --resume` runs and to maintain backwards compatibility.

**Test plan**
`sparseml.yolov5.train  --weights zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned75_quant-none?recipe_type=transfer_learn  --recipe zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned75_quant-none?recipe_type=transfer_learn  --patience 0  --cfg yolov5s.yaml  --hyp hyps/hyp.finetune.yaml`

`sparseml.yolov5.export_onnx --weights "path_to_Intermediate_checkpoint_created_above"`