### PR TITLE
[Cherry Pick][Fix] Prevent the model with the flag `--deepsparse` to go through the `attempt_download()` route

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -342,7 +342,7 @@ class DetectMultiBackend(nn.Module):
         nhwc = coreml or saved_model or pb or tflite or edgetpu  # BHWC formats (vs torch BCWH)
         stride = 32  # default stride
         cuda = torch.cuda.is_available() and device.type != 'cpu'  # use CUDA
-        if not (pt or triton):
+        if not (pt or triton or deepsparse):
             w = attempt_download(w)  # download if not local
 
         if pt or sparsezoo and not deepsparse:  # PyTorch


### PR DESCRIPTION
Cherry Pick for #190 