### PR TITLE
add hardcoded onnx graph input shape even for dyanmic exports

### DIFF
--- a/utils/neuralmagic/utils.py
+++ b/utils/neuralmagic/utils.py
@@ -8,6 +8,7 @@ import torch
 import yaml
 from sparseml.pytorch.optim import ScheduledModifierManager
 from sparseml.pytorch.utils import ModuleExporter, download_framework_model_by_recipe_type
+from sparseml.onnx.utils import override_model_input_shape
 from sparsezoo import Model
 
 from models.yolo import Model as Yolov5Model
@@ -212,6 +213,10 @@ def neuralmagic_onnx_export(
     )
 
     saved_model_path = save_dir / onnx_file_name
+
+    # set model input shape to a static shape (graph is still dynamic compatible)
+    # for performance with deepsparse engine + extractable shape for analysis
+    override_model_input_shape(saved_model_path, list(sample_data.shape))
 
     nm_log_console(f"Exported ONNX model to {saved_model_path}")
 


### PR DESCRIPTION
adds a pass to set the onnx graph input shape to the sample data shape even for dyanmic exports.

this is because dynamic shape export is required to change image size, however deepsparse engine requires a static input shape and static input shapes provide good information for model analysis and shape inference

depends on https://github.com/neuralmagic/sparseml/pull/1471

**test_plan**
new dynamic export: 
```bash
sparseml.yolov5.export_onnx \
  --weights zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned65_quant-none \
  --dynamic
```

verified weights are hardcoded:
```python
>>> model.graph.input
[name: "images"
type {
  tensor_type {
    elem_type: 1
    shape {
      dim {
        dim_value: 1
      }
      dim {
        dim_value: 3
      }
      dim {
        dim_value: 640
      }
      dim {
        dim_value: 640
      }
    }
  }
}
]
```

dynamic inference:

```
from deepsparse import Pipeline
import numpy

model_path = ...
yolo_640 = Pipeline.create(task="yolo", model_path=model_path, image_size=640)
yolo_320 = Pipeline.create(task="yolo", model_path=model_path, image_size=320)

yolo_640(images=[numpy.random.randn(1, 3, 640, 640)])
yolo_320(images=[numpy.random.randn(1, 3, 320, 320)])
```