### PR TITLE
update build versions for NM fork pypi push

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,23 @@ def read_requirements():
     with open(os.path.join(build_dir, "yolov5", "requirements.txt")) as f:
         return f.read().splitlines()
 
+
+# default variable to be overwritten by the version.py file
+version = "unknown"
+# load and overwrite version and release info from version.py
+try:
+    exec(open(os.path.join("utils", "neuralmagic", "version.py")).read())
+except:
+    # in build.sh utils may be nested under yolov5/
+    exec(open(os.path.join("yolov5", "utils", "neuralmagic", "version.py")).read())
+
 setuptools.setup(
     name="yolov5",
-    version='6.2.0',
+    version=version,  # major.minor.patch to match NM repos, fourth entry is either yolov5 base version or nightly date
     author="",
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
-    url="https://github.com/ultralytics/yolov5",
+    url="https://github.com/neuralmagic/yolov5",
     packages=['yolov5', 'yolov5.models', 'yolov5.utils'],
     python_requires=">=3.6",
     install_requires=read_requirements(),

--- a/utils/neuralmagic/version.py
+++ b/utils/neuralmagic/version.py
@@ -1,0 +1,39 @@
+"""
+Functionality for storing and setting the version info for SparseML
+"""
+
+from datetime import date
+
+
+nm_version_base = "1.5.0"
+yolov5_version_base = "60200"  # 6.2.0
+is_release = False  # change to True to set the generated version as a release version
+
+
+def _generate_version():
+    return (
+        f"{nm_version_base}.{yolov5_version_base}"
+        if is_release
+        else f"{nm_version_base}.{date.today().strftime('%Y%m%d')}"
+    )
+
+
+__all__ = [
+    "__version__",
+    "nm_version_base",
+    "yolov5_version_base",
+    "is_release",
+    "version",
+    "version_major",
+    "version_minor",
+    "version_bug",
+    "version_build",
+    "version_major_minor",
+]
+__version__ = _generate_version()
+
+version = __version__
+version_major, version_minor, version_bug, version_build = version.split(".") + (
+    [None] if len(version.split(".")) < 4 else []
+)  # handle conditional for version being 3 parts or 4 (4 containing build date)
+version_major_minor = f"{version_major}.{version_minor}"


### PR DESCRIPTION
moving forward build versions will by synced with the latest NM release (patch version is async) with the fourth slot either the nightly date for nightly or the base yolov5 version for release

example nightly: `1.5.0.20230331`
example release: `1.5.0.60201`