### PR TITLE
[Bug-fix] Set batch size min to world size

### DIFF
--- a/utils/neuralmagic/sparsification_manager.py
+++ b/utils/neuralmagic/sparsification_manager.py
@@ -382,7 +382,7 @@ class SparsificationManager(object):
         return ema, amp, scaler
 
     def rescale_gradient_accumulation(
-        self, batch_size: int, accumulate: int, image_size: int
+        self, batch_size: int, accumulate: int
     ) -> Tuple[int, int]:
         """
         Used when autobatch and QAT are both enabled. Training with QAT adds additional


### PR DESCRIPTION
There's currently a bug with scaling down batch size for QAT, as batch size must be a multiple of the world size but it can be set to 1 when scaling down. This fix updates the batch size floor to be equal to the world size.

**Test plan**
Tested locally with command

```
python -m torch.distributed.run --no_python --nproc_per_node 2 \
  sparseml.yolov5.train \
  --cfg yolov5x6.yaml \
  --weights "zoo:cv/detection/yolov5-x6/pytorch/ultralytics/coco/pruned75-none" \
  --recipe "zoo:cv/detection/yolov5-x6/pytorch/ultralytics/voc/pruned75_quant-none" \
  --data coco128.yaml \
  --batch-size 2 \
  --gradient-accum-steps 32 \
  --hyp hyps/hyp.VOC.yaml \
  --imgsz 1280 \
  --patience 0 \
  --workers 4
```
