### PR TITLE
[fix] remove image_size from call to rescale_gradient_accumulation (#202(

### DIFF
--- a/train.py
+++ b/train.py
@@ -314,7 +314,6 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
                 new_batch_size, new_accumulate = sparsification_manager.rescale_gradient_accumulation(
                     batch_size=batch_size, 
                     accumulate=accumulate, 
-                    image_size=imgsz
                 )
                 if new_batch_size != batch_size:
                     batch_size = new_batch_size


### PR DESCRIPTION
#200 included a side change to remove the now unused `image_size` arg from the function signature but did not update the call site.

this PR fixes that.

**test_plan:**
Reproduced reported error with a sample quantization recipe and verified this PR resolves it