### PR TITLE
[Bug-fix] Remove non-conditional reading of kwargs

### DIFF
--- a/export.py
+++ b/export.py
@@ -690,7 +690,7 @@ def main(opt):
         run(**vars(opt))
 
 def export_run(**kwargs):
-    opt = parse_opt() if not kwargs else parse_opt(skip_parse=True)
+    opt = parse_opt(True, skip_parse=bool(kwargs))
     for k, v in kwargs.items():
         setattr(opt, k, v)
     main(opt)

--- a/export.py
+++ b/export.py
@@ -676,7 +676,6 @@ def parse_opt(skip_parse=False):
         default=None,
         help="local path or SparseZoo stub to a recipe to be applied"
                 " in one-shot manner before exporting")
-    print_args(vars(opt))
     
     if skip_parse:
         opt = parser.parse_args([])

--- a/export.py
+++ b/export.py
@@ -676,7 +676,6 @@ def parse_opt(skip_parse=False):
         default=None,
         help="local path or SparseZoo stub to a recipe to be applied"
                 " in one-shot manner before exporting")
-    opt = parser.parse_args()
     print_args(vars(opt))
     
     if skip_parse:

--- a/export.py
+++ b/export.py
@@ -682,6 +682,7 @@ def parse_opt(skip_parse=False):
         opt = parser.parse_args([])
     else: 
         opt = parser.parse_args()
+        print_args(vars(opt))
     return opt
 
 

--- a/train.py
+++ b/train.py
@@ -726,7 +726,7 @@ def main(opt, callbacks=Callbacks()):
 
 def run(**kwargs):
     # Usage: import train; train.run(data='coco128.yaml', imgsz=320, weights='yolov5m.pt')
-    opt = parse_opt(True)
+    opt = parse_opt(True, skip_parse=bool(kwargs))
     for k, v in kwargs.items():
         setattr(opt, k, v)
     main(opt)


### PR DESCRIPTION
This PR fixes a bug where args are read from the CLI regardless of the skip_parse setting. When YOLOv5 is run by another program (such as Sparsify), we want to enable skip_parse so that the CLI args to sparsify aren't read in as CLI argument to YOLOv5