### PR TITLE
Enable quantization of inputs

### DIFF
--- a/export.py
+++ b/export.py
@@ -176,7 +176,8 @@ def export_onnx(model, im, file, opset, dynamic, simplify, sparsified=False, dat
             model=model,
             save_dir=f.parent,
             number_export_samples=export_samples,
-            image_size=image_size[0]
+            image_size=image_size[0],
+            onnx_path=f,
         )
 
     # Checks


### PR DESCRIPTION
Logic for quantization of inputs was already in the codebase, but was being bypassed because the onnx path was not passed to the export samples function. This PR fixes that.

Testing plan: tested on yolov5-s base_quant and verified inputs are properly quantized
