### PR TITLE
Pin Pillow version to <10.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 matplotlib>=3.2.2
 numpy>=1.18.5
 opencv-python>=4.1.1,<=4.6.0.66
-Pillow>=7.1.2
+Pillow>=7.1.2,<10.0.0
 PyYAML>=5.3.1
 requests>=2.23.0
 scipy>=1.4.1


### PR DESCRIPTION
`Pillow` 10.0.0 appears to trigger the following error, pinning to lower until resolved

```python
"AttributeError: 'FreeTypeFont' object has no attribute 'getsize'" and missing expected files
```

**test_plan:**
reproduced and verified locally