### PR TITLE
Update the yolo model to always be exported as model.onnx

### DIFF
--- a/utils/neuralmagic/utils.py
+++ b/utils/neuralmagic/utils.py
@@ -196,7 +196,8 @@ def neuralmagic_onnx_export(
             if weights_path.parent.stem == "weights"
             else weights_path.parent / "DeepSparse_Deployment"
         )
-        onnx_file_name = weights_path.with_suffix(".onnx").name
+        onnx_file = weights_path.with_suffix(".onnx").name
+        onnx_file_name = onnx_file.replace(onnx_file, "model.onnx")
 
     save_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
For this bug: https://app.asana.com/0/1204322589046915/1205070658998384/f

This will update the case to make sure the exported model is called`model.onnx`
Verified correctness through local testing